### PR TITLE
Added default HTTPs site.

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -36,3 +36,17 @@ server {
     root /var/www/html;
   }
 }
+
+# Default 443 Host
+server {
+  listen 443 ssl default;
+  server_name localhost;
+
+  access_log /data/logs/default.log proxy;
+
+  ssl_certificate /data/nginx/dummycert.pem;
+  ssl_certificate_key /data/nginx/dummykey.pem;
+  ssl_ciphers aNULL;
+
+  return 444;
+}

--- a/rootfs/etc/services.d/nginx/run
+++ b/rootfs/etc/services.d/nginx/run
@@ -21,5 +21,19 @@ chown root /tmp/nginx
 # Dynamically generate resolvers file
 echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf) ";" > /etc/nginx/conf.d/include/resolvers.conf
 
+# Generate dummy self-signed certificate.
+if [ ! -f /data/nginx/dummycert.pem ] || [ ! -f /data/nginx/dummykey.pem ]
+then
+  openssl req \
+    -new \
+    -newkey rsa:2048 \
+    -days 3650 \
+    -nodes \
+    -x509 \
+    -subj '/O=Nginx Proxy Manager/OU=Dummy Certificate/CN=localhost' \
+    -keyout /data/nginx/dummykey.pem \
+    -out /data/nginx/dummycert.pem
+fi
+
 # Run
 exec nginx


### PR DESCRIPTION
Without a default site for HTTPs, another configured host will be wrongly used.

For example, when trying to access, via HTTP, a host that has not been setup yet, we get the "Congratulations" page as expected.  However, doing the same via HTTPs does't show this default page, but shows a configured proxy host (for which SSL is enabled).

The same issue happen when configuring a host without enabling SSL:  Access the host over HTTP works fine, but accessing the same host via HTTPs will show the page associated to another configured host.

Since there is no certificate associated to the default site, its configuration only return the special code `444`, which makes nginx to close the connection.
