### PR TITLE
Restored ssl_ciphers to aNULL for default HTTPs site.

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -46,7 +46,7 @@ server {
 
   ssl_certificate /data/nginx/dummycert.pem;
   ssl_certificate_key /data/nginx/dummykey.pem;
-  include conf.d/include/ssl-ciphers.conf;
+  ssl_ciphers aNULL;
 
   return 444;
 }


### PR DESCRIPTION
This is to make sure the browser doesn't show a certificate warning (for a connection that will be dropped anyway) by breaking the SSL handshake early.