### PR TITLE
Ignore default location when defined in advanced config

### DIFF
--- a/src/backend/templates/dead_host.conf
+++ b/src/backend/templates/dead_host.conf
@@ -10,10 +10,13 @@ server {
 
 {{ advanced_config }}
 
+{% if use_default_location %}
   location / {
 {% include "_forced_ssl.conf" %}
 {% include "_hsts.conf" %}
     return 404;
   }
+{% endif %}
+
 }
 {% endif %}

--- a/src/backend/templates/proxy_host.conf
+++ b/src/backend/templates/proxy_host.conf
@@ -16,6 +16,7 @@ server {
 
 {{ advanced_config }}
 
+{% if use_default_location %}
   location / {
     {%- if access_list_id > 0 -%}
     # Access List
@@ -35,5 +36,7 @@ server {
     # Proxy!
     include conf.d/include/proxy.conf;
   }
+{% endif %}
+
 }
 {% endif %}

--- a/src/backend/templates/redirection_host.conf
+++ b/src/backend/templates/redirection_host.conf
@@ -12,6 +12,7 @@ server {
 
 {{ advanced_config }}
 
+{% if use_default_location %}
   location / {
 {% include "_forced_ssl.conf" %}
 {% include "_hsts.conf" %}
@@ -22,5 +23,7 @@ server {
         return 301 $scheme://{{ forward_domain_name }};
     {% endif %}
   }
+{% endif %}
+
 }
 {% endif %}

--- a/src/frontend/js/app/nginx/proxy/form.ejs
+++ b/src/frontend/js/app/nginx/proxy/form.ejs
@@ -152,6 +152,12 @@
                 <div role="tabpanel" class="tab-pane" id="advanced">
                     <div class="row">
                         <div class="col-md-12">
+                            <p>Nginx variables available to you are:</p>
+                            <ul class="text-monospace">
+                                <li>$server          # Host/IP</li>
+                                <li>$port            # Port Number</li>
+                                <li>$forward_scheme  # http or https</li>
+                            </ul>
                             <div class="form-group mb-0">
                                 <label class="form-label"><%- i18n('all-hosts', 'advanced-config') %></label>
                                 <textarea name="advanced_config" rows="8" class="form-control text-monospace" placeholder="# <%- i18n('all-hosts', 'advanced-warning') %>"><%- advanced_config %></textarea>


### PR DESCRIPTION
Fixes #65 by ignoring the built-in default location when it's detected in the advanced configuration.

In essence, the regex searches for `location / {` in many forms.