### PR TITLE
Update the docker-compose

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -59,6 +59,8 @@ services:
   db:
     image: jc21/mariadb-aria
     restart: always
+    ports:
+      - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: "password123"
       MYSQL_DATABASE: "nginxproxymanager"


### PR DESCRIPTION
Added the ports to be open on the jc21/mariadb-aria.

I was getting a connection error of: 
`app_1  | [5/3/2019] [2:04:54 AM] [Global   ] › ✖  error     connect ECONNREFUSED 192.168.2.109:3306` 

I was able to resolve this by adding in the ports that need to be opened in the docker-compose script.