### PR TITLE
Open up lets Encrypt acme challenge config

### DIFF
--- a/rootfs/etc/nginx/conf.d/include/letsencrypt-acme-challenge.conf
+++ b/rootfs/etc/nginx/conf.d/include/letsencrypt-acme-challenge.conf
@@ -2,7 +2,10 @@
 # We use ^~ here, so that we don't check other regexes (for speed-up). We actually MUST cancel
 # other regex checks, because in our other config files have regex rule that denies access to files with dotted names.
 location ^~ /.well-known/acme-challenge/ {
+    # Since this is for letsencrypt authentication of a domain and they do not give IP ranges of their infrastructure
+    # we need to open up access by turning off auth and IP ACL for this location.
     auth_basic off;
+    allow all;
 
     # Set correct content type. According to this:
     # https://community.letsencrypt.org/t/using-the-webroot-domain-verification-method/1445/29


### PR DESCRIPTION
As discussed in Issue #135. Since Lets Encrypt don't publish IP ranges that their acme challenge service will be sourced from, we need to allow free access to this location special to override any IP ACLs added by Advanced Custom Nginx Configuration. Due to the way Nginx config is applied, this only applies to the regex and below, keeping the IP ACLs working for the rest of the website.