### PR TITLE
Allow including custom nginx conf files

### DIFF
--- a/doc/ADVANCED_NGINX.md
+++ b/doc/ADVANCED_NGINX.md
@@ -1,0 +1,17 @@
+## Advanced Nginx Configuration
+
+If you are a more advanced user, you might be itching for extra Nginx customizability.
+
+NPM has the ability to include different custom configuration snippets in different places.
+
+You can add your custom configuration snippet files at `/data/nginx/custom` as follow:
+
+`/data/nginx/custom/root.conf`: Included at the very end of nginx.conf
+`/data/nginx/custom/http.conf`: Included at the end of the main http block
+`/data/nginx/custom/server_proxy.conf`: Included at the end of every proxy server block
+`/data/nginx/custom/server_redirect.conf`: Included at the end of every redirection server block
+`/data/nginx/custom/server_stream.conf`: Included at the end of every stream server block
+`/data/nginx/custom/server_stream_tcp.conf`: Included at the end of every TCP stream server block
+`/data/nginx/custom/server_stream_udp.conf`: Included at the end of every UDP stream server block
+
+Every file is optional.

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -78,7 +78,7 @@ http {
   include /data/nginx/temp/*.conf;
 
   # Custom
-  include /data/nginx/custom/http.conf;
+  include /data/nginx/custom/http[.]conf;
 }
 
 stream {
@@ -87,4 +87,4 @@ stream {
 }
 
 # Custom
-include /data/nginx/custom/root.conf;
+include /data/nginx/custom/root[.]conf;

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -76,6 +76,9 @@ http {
   include /data/nginx/redirection_host/*.conf;
   include /data/nginx/dead_host/*.conf;
   include /data/nginx/temp/*.conf;
+
+  # Custom
+  include /data/nginx/custom/http.conf;
 }
 
 stream {
@@ -83,3 +86,5 @@ stream {
     include /data/nginx/stream/*.conf;
 }
 
+# Custom
+include /data/nginx/custom/root.conf;

--- a/src/backend/templates/proxy_host.conf
+++ b/src/backend/templates/proxy_host.conf
@@ -42,6 +42,6 @@ server {
 {% endif %}
 
   # Custom
-  include /data/nginx/custom/server_proxy.conf;
+  include /data/nginx/custom/server_proxy[.]conf;
 }
 {% endif %}

--- a/src/backend/templates/proxy_host.conf
+++ b/src/backend/templates/proxy_host.conf
@@ -41,5 +41,7 @@ server {
   }
 {% endif %}
 
+  # Custom
+  include /data/nginx/custom/server_proxy.conf;
 }
 {% endif %}

--- a/src/backend/templates/redirection_host.conf
+++ b/src/backend/templates/redirection_host.conf
@@ -25,5 +25,7 @@ server {
   }
 {% endif %}
 
+  # Custom
+  include /data/nginx/custom/server_redirect.conf;
 }
 {% endif %}

--- a/src/backend/templates/redirection_host.conf
+++ b/src/backend/templates/redirection_host.conf
@@ -26,6 +26,6 @@ server {
 {% endif %}
 
   # Custom
-  include /data/nginx/custom/server_redirect.conf;
+  include /data/nginx/custom/server_redirect[.]conf;
 }
 {% endif %}

--- a/src/backend/templates/stream.conf
+++ b/src/backend/templates/stream.conf
@@ -7,12 +7,20 @@
 server {
   listen {{ incoming_port }};
   proxy_pass {{ forward_ip }}:{{ forwarding_port }};
+
+  # Custom
+  include /data/nginx/custom/server_stream.conf;
+  include /data/nginx/custom/server_stream_tcp.conf;
 }
 {% endif %}
 {% if udp_forwarding == 1 or udp_forwarding == true %}
 server {
   listen {{ incoming_port }} udp;
   proxy_pass {{ forward_ip }}:{{ forwarding_port }};
+
+  # Custom
+  include /data/nginx/custom/server_stream.conf;
+  include /data/nginx/custom/server_stream_udp.conf;
 }
 {% endif %}
 {% endif %}

--- a/src/backend/templates/stream.conf
+++ b/src/backend/templates/stream.conf
@@ -9,8 +9,8 @@ server {
   proxy_pass {{ forward_ip }}:{{ forwarding_port }};
 
   # Custom
-  include /data/nginx/custom/server_stream.conf;
-  include /data/nginx/custom/server_stream_tcp.conf;
+  include /data/nginx/custom/server_stream[.]conf;
+  include /data/nginx/custom/server_stream_tcp[.]conf;
 }
 {% endif %}
 {% if udp_forwarding == 1 or udp_forwarding == true %}
@@ -19,8 +19,8 @@ server {
   proxy_pass {{ forward_ip }}:{{ forwarding_port }};
 
   # Custom
-  include /data/nginx/custom/server_stream.conf;
-  include /data/nginx/custom/server_stream_udp.conf;
+  include /data/nginx/custom/server_stream[.]conf;
+  include /data/nginx/custom/server_stream_udp[.]conf;
 }
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Give advanced users more flexibility by allowing them to include custom config files at differents locations in the nginx configuration.

`/data/nginx/custom/root.conf`: Included at the very end of nginx.conf
`/data/nginx/custom/http.conf`: Included at the end of the main `http` block
`/data/nginx/custom/server_proxy.conf`: Included at the end of every proxy `server` block
`/data/nginx/custom/server_redirect.conf`: Included at the end of every redirection `server` block
`/data/nginx/custom/server_stream.conf`: Included at the end of every stream `server` block
`/data/nginx/custom/server_stream_tcp.conf`: Included at the end of every TCP stream `server` block
`/data/nginx/custom/server_stream_udp.conf`: Included at the end of every UDP stream `server` block