### PR TITLE
Selection of the ssl protocols/ciphers is done using the default sever block

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -47,7 +47,7 @@ server {
 
   ssl_certificate /data/nginx/dummycert.pem;
   ssl_certificate_key /data/nginx/dummykey.pem;
-  ssl_ciphers aNULL;
+  include conf.d/include/ssl-ciphers.conf;
 
   return 444;
 }


### PR DESCRIPTION
The check for allowed SSL protocols is done before SNI, thus the default server block is always used.

See https://www.ruby-forum.com/t/ssl-protocols-per-server/232557/11