### PR TITLE
Increased nice_name field length to allow a larger number of LE certificates generation

### DIFF
--- a/src/backend/migrations/20180618015850_initial.js
+++ b/src/backend/migrations/20180618015850_initial.js
@@ -153,7 +153,7 @@ exports.up = function (knex/*, Promise*/) {
                 table.integer('owner_user_id').notNull().unsigned();
                 table.integer('is_deleted').notNull().unsigned().defaultTo(0);
                 table.string('provider').notNull();
-                table.string('nice_name').notNull().defaultTo('');
+                table.string('nice_name', 2000).notNull().defaultTo('');
                 table.json('domain_names').notNull();
                 table.dateTime('expires_on').notNull();
                 table.json('meta').notNull();

--- a/src/backend/schema/definitions.json
+++ b/src/backend/schema/definitions.json
@@ -172,7 +172,7 @@
       "description": "Domain Names separated by a comma",
       "example": "*.jc21.com,blog.jc21.com",
       "type": "array",
-      "maxItems": 15,
+      "maxItems": 50,
       "uniqueItems": true,
       "items": {
         "type": "string",


### PR DESCRIPTION
We experienced certain issues while implementing nginx manager in our environment. Notably, since we are using microservices infrastructure, we run a large number of services requiring to use the same SSL certificate. Currently, nginx manager supports only 15 concurrent certificates generation via Letsencrypt, so we made it 50.