### PR TITLE
fix ipv6 resolver setup for nginx

### DIFF
--- a/rootfs/etc/services.d/nginx/run
+++ b/rootfs/etc/services.d/nginx/run
@@ -21,8 +21,8 @@ mkdir -p /tmp/nginx/body \
 touch /var/log/nginx/error.log && chmod 777 /var/log/nginx/error.log && chmod -R 777 /var/cache/nginx
 chown root /tmp/nginx
 
-# Dynamically generate resolvers file
-echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf) ";" > /etc/nginx/conf.d/include/resolvers.conf
+# Dynamically generate resolvers file, if resolver is IPv6, enclose in `[]`
+echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf) ";" > /etc/nginx/conf.d/include/resolvers.conf
 
 # Generate dummy self-signed certificate.
 if [ ! -f /data/nginx/dummycert.pem ] || [ ! -f /data/nginx/dummykey.pem ]


### PR DESCRIPTION
Currently IPv6 resolvers defined in resolv.conf are being added to /etc/nginx/conf.d/includes/resolvers.conf in plain text.  Nginx requires IPv6 resolvers to be enclosed by `[]`, this PR does that. 