### PR TITLE
Documentation update

### DIFF
--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -88,6 +88,7 @@ Then:
 docker-compose up -d
 ```
 
+The config file (config.json) must be present in this directory.
 
 ### Running on Raspberry PI / ARM devices
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -6,7 +6,7 @@
 
 Don't worry, this is easy to do.
 
-The app requires a configuration file to let it know what database you're using.
+The app requires a configuration file to let it know what database you're using. By default, this file is called config.json. 
 
 Here's an example configuration for `mysql` (or mariadb) that is compatible with the docker-compose example below:
 


### PR DESCRIPTION
Updated documents to include the default name of the config file, and indicate it must be in the root of where the docker-compose is run