### PR TITLE
Improve terminal script colors

### DIFF
--- a/scripts/buildx
+++ b/scripts/buildx
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-CYAN='\E[1;36m'
-YELLOW='\E[1;33m'
-BLUE='\E[1;34m'
-GREEN='\E[1;32m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
-echo -e "${BLUE}❯ ${CYAN}Building docker multiarch: ${YELLOW}${*}${RESET}"
+log "Building docker multiarch: ${YELLOW}${*}" "info"
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${DIR}/.." || exit 1
@@ -35,5 +31,5 @@ docker buildx build \
 
 rc=$?
 docker buildx rm "${BUILDX_NAME:-npm}"
-echo -e "${BLUE}❯ ${GREEN}Multiarch build Complete${RESET}"
+log "Multiarch build Complete" "success"
 exit $rc

--- a/scripts/destroy-dev
+++ b/scripts/destroy-dev
@@ -2,10 +2,7 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-CYAN='\E[1;36m'
-BLUE='\E[1;34m'
-RED='\E[1;31m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 COMPOSE_PROJECT_NAME="npmdev"
 COMPOSE_FILE="docker/docker-compose.dev.yml"
@@ -15,8 +12,8 @@ export COMPOSE_FILE COMPOSE_PROJECT_NAME
 # Make sure docker exists
 if hash docker-compose 2>/dev/null; then
 	cd "${DIR}/.."
-	echo -e "${BLUE}❯ ${CYAN}Destroying Dev Stack ...${RESET}"
+	log "Destroying Dev Stack ..." "info"
 	docker-compose down --remove-orphans --volumes
 else
-	echo -e "${RED}❯ docker-compose command is not available${RESET}"
+	log "docker-compose command is not available" "danger"
 fi

--- a/scripts/docs-build
+++ b/scripts/docs-build
@@ -2,18 +2,14 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-CYAN='\E[1;36m'
-BLUE='\E[1;34m'
-RED='\E[1;31m'
-GREEN='\E[1;32m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 # Ensure docker-compose exists
 if hash docker 2>/dev/null; then
 	cd "${DIR}/.."
-	echo -e "${BLUE}❯ ${CYAN}Building Docs ...${RESET}"
+	log "Building Docs ..." "info"
 	docker run --rm -e CI=true -v "$(pwd)/docs:/app/docs" -w /app/docs node:alpine sh -c "yarn install && yarn build && chown -R $(id -u):$(id -g) /app/docs"
-	echo -e "${BLUE}❯ ${GREEN}Building Docs Complete${RESET}"
+	log "Building Docs Complete" "success"
 else
-	echo -e "${RED}❯ docker command is not available${RESET}"
+	log "docker command is not available" "danger"
 fi

--- a/scripts/docs-upload
+++ b/scripts/docs-upload
@@ -2,13 +2,9 @@
 
 # Note: This script is designed to be run inside CI builds
 
-CYAN='\E[1;36m'
-YELLOW='\E[1;33m'
-BLUE='\E[1;34m'
-GREEN='\E[1;32m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
-echo -e "${BLUE}❯ ${CYAN}Uploading docs in: ${YELLOW}$1${RESET}"
+log "Uploading docs in: ${YELLOW}$1" "info"
 
 cd "$1" || exit 1
 ALL_FILES=$(find . -follow)
@@ -52,4 +48,4 @@ do
 	fi
 done
 
-echo -e "${BLUE}❯ ${GREEN}Upload Complete${RESET}"
+log "Upload Complete" "success"

--- a/scripts/frontend-build
+++ b/scripts/frontend-build
@@ -2,20 +2,16 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-CYAN='\E[1;36m'
-BLUE='\E[1;34m'
-RED='\E[1;31m'
-GREEN='\E[1;32m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 DOCKER_IMAGE=jc21/alpine-nginx-full:node
 
 # Ensure docker exists
 if hash docker 2>/dev/null; then
 	cd "${DIR}/.."
-	echo -e "${BLUE}❯ ${CYAN}Building Frontend ...${RESET}"
+	log "Building Frontend ..." "info"
 	docker run --rm -e CI=true -v "$(pwd)/frontend:/app/frontend" -w /app/frontend "$DOCKER_IMAGE" sh -c "yarn install && yarn build && yarn build && chown -R $(id -u):$(id -g) /app/frontend"
-	echo -e "${BLUE}❯ ${GREEN}Building Frontend Complete${RESET}"
+	log "Building Frontend Complete" "success"
 else
-	echo -e "${RED}❯ docker command is not available${RESET}"
+	log "docker command is not available" "danger"
 fi

--- a/scripts/install-s6
+++ b/scripts/install-s6
@@ -2,11 +2,7 @@
 
 # Note: This script is designed to be run inside a Docker Build for a container
 
-CYAN='\E[1;36m'
-YELLOW='\E[1;33m'
-BLUE='\E[1;34m'
-GREEN='\E[1;32m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 S6_OVERLAY_VERSION=1.22.1.0
 TARGETPLATFORM=$1
@@ -26,9 +22,9 @@ case $TARGETPLATFORM in
 		;;
 esac
 
-echo -e "${BLUE}❯ ${CYAN}Installing S6-overlay v${S6_OVERLAY_VERSION} for ${YELLOW}${TARGETPLATFORM} (${S6_ARCH})${RESET}"
+log "Installing S6-overlay v${S6_OVERLAY_VERSION} for ${YELLOW}${TARGETPLATFORM} (${S6_ARCH})" "info"
 
 curl -L -o "/tmp/s6-overlay-${S6_ARCH}.tar.gz" "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.gz" \
 	&& tar -xzf "/tmp/s6-overlay-${S6_ARCH}.tar.gz" -C /
 
-echo -e "${BLUE}❯ ${GREEN}S6-overlay install Complete${RESET}"
+log "S6-overlay install Complete" "success"

--- a/scripts/log
+++ b/scripts/log
@@ -1,0 +1,23 @@
+CYAN='\E[1;36m'
+YELLOW='\E[1;33m'
+BLUE='\E[1;34m'
+GREEN='\E[1;32m'
+RED='\E[1;31m'
+RESET='\E[0m'
+
+# prints a log message
+log () {
+    if [ "$2" == "info" ] ; then
+        printf "${BLUE}❯ ${CYAN}%b${RESET}\n" "$1";
+    elif [ "$2" == "success" ] ; then
+        printf "${BLUE}❯ ${GREEN}%b${RESET}\n" "$1";
+    elif [ "$2" == "danger" ] ; then
+        printf "${RED}❯ %b${RESET}\n" "$1";
+    elif [ "$2" == "warning" ] ; then
+        printf "${BLUE}❯ ${YELLOW}%b${RESET}\n" "$1";
+    elif [ "$2" == "hint" ] ; then
+        printf "${YELLOW}Hint: ${RESET}%b\n" "$1";
+    else #default color
+        printf "${BLUE}❯ ${RESET}%b\n" "$1";
+    fi
+}

--- a/scripts/start-dev
+++ b/scripts/start-dev
@@ -2,11 +2,7 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-CYAN='\E[1;36m'
-BLUE='\E[1;34m'
-YELLOW='\E[1;33m'
-RED='\E[1;31m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 COMPOSE_PROJECT_NAME="npmdev"
 COMPOSE_FILE="docker/docker-compose.dev.yml"
@@ -15,23 +11,22 @@ export COMPOSE_FILE COMPOSE_PROJECT_NAME
 # Ensure docker-compose exists
 if hash docker-compose 2>/dev/null; then
 	cd "${DIR}/.."
-	echo -e "${BLUE}❯ ${CYAN}Starting Dev Stack ...${RESET}"
+	log "Starting Dev Stack ..." "info"
 
 	docker-compose up -d --remove-orphans --force-recreate --build
 
 	echo ""
-	echo -e "${CYAN}Admin UI:     http://127.0.0.1:3081${RESET}"
-	echo -e "${CYAN}Nginx:        http://127.0.0.1:3080${RESET}"
-	echo -e "${CYAN}Swagger Doc:  http://127.0.0.1:3001${RESET}"
+	log "Admin UI:     http://127.0.0.1:3081" "success"
+	log "Nginx:        http://127.0.0.1:3080" "success"
+	log "Swagger Doc:  http://127.0.0.1:300" "success"
 	echo ""
 
 	if [ "$1" == "-f" ]; then
-		echo -e "${BLUE}❯ ${YELLOW}Following Backend Container:${RESET}"
+		log "Following Backend Container:" "warning"
 		docker logs -f npmdev_npm_1
 	else
-		echo -e "${YELLOW}Hint:${RESET} You can follow the output of some of the containers with:"
-		echo "  docker logs -f npmdev_npm_1"
+		log "You can follow the output of some of the containers with:\n  docker logs -f npmdev_npm_1" "hint"
 	fi
 else
-	echo -e "${RED}❯ docker-compose command is not available${RESET}"
+	log "docker-compose command is not available" "danger"
 fi

--- a/scripts/stop-dev
+++ b/scripts/stop-dev
@@ -2,10 +2,7 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-CYAN='\E[1;36m'
-BLUE='\E[1;34m'
-RED='\E[1;31m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 COMPOSE_PROJECT_NAME="npmdev"
 COMPOSE_FILE="docker/docker-compose.dev.yml"
@@ -15,8 +12,8 @@ export COMPOSE_FILE COMPOSE_PROJECT_NAME
 # Make sure docker exists
 if hash docker-compose 2>/dev/null; then
 	cd "${DIR}/.."
-	echo -e "${BLUE}❯ ${CYAN}Stopping Dev Stack ...${RESET}"
+	log "Stopping Dev Stack ..." "info"
 	docker-compose down --remove-orphans
 else
-	echo -e "${RED}❯ docker-compose command is not available${RESET}"
+	log "docker-compose command is not available" "danger"
 fi

--- a/scripts/test-dev
+++ b/scripts/test-dev
@@ -2,10 +2,7 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-CYAN='\E[1;36m'
-BLUE='\E[1;34m'
-RED='\E[1;31m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 COMPOSE_PROJECT_NAME="npmdev"
 COMPOSE_FILE="docker/docker-compose.dev.yml"
@@ -14,8 +11,8 @@ export COMPOSE_FILE COMPOSE_PROJECT_NAME
 # Ensure docker-compose exists
 if hash docker-compose 2>/dev/null; then
 	cd "${DIR}/.."
-	echo -e "${BLUE}❯ ${CYAN}Testing Dev Stack ...${RESET}"
+	log "Testing Dev Stack ..." "info"
 	docker-compose exec -T npm bash -c "cd /app/backend && task test"
 else
-	echo -e "${RED}❯ docker-compose command is not available${RESET}"
+  log "docker-compose command is not available" "danger"
 fi

--- a/scripts/wait-healthy
+++ b/scripts/wait-healthy
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-CYAN='\E[1;36m'
-YELLOW='\E[1;33m'
-BLUE='\E[1;34m'
-GREEN='\E[1;32m'
-RED='\E[1;31m'
-RESET='\E[0m'
+. $(dirname "$0")/log
 
 if [ "$1" == "" ]; then
 	echo "Waits for a docker container to be healthy."
@@ -18,7 +13,7 @@ LOOPCOUNT=0
 HEALTHY=
 LIMIT=${2:-90}
 
-echo -e "${BLUE}❯ ${CYAN}Waiting for healthy: ${YELLOW}${SERVICE}${RESET}"
+log "Waiting for healthy: ${YELLOW}${SERVICE}" "info"
 
 until [ "${HEALTHY}" = "healthy" ]; do
 	echo -n "."
@@ -29,10 +24,10 @@ until [ "${HEALTHY}" = "healthy" ]; do
 	if [ "$LOOPCOUNT" == "$LIMIT" ]; then
 		echo ""
 		echo ""
-		echo -e "${BLUE}❯ ${RED}Timed out waiting for healthy${RESET}"
+		log "Timed out waiting for healthy" "danger"
 		exit 1
 	fi
 done
 
 echo ""
-echo -e "${BLUE}❯ ${GREEN}Healthy!${RESET}"
+log "Healthy!" "success"


### PR DESCRIPTION
If a terminal cannot interpret \e[* color codes, then it will be "polluted" which makes output harder to read. tput will handle escape characters depending on the terminal capabilities.

![Screen Shot 2020-04-15 at 10 04 19 PM](https://user-images.githubusercontent.com/35218/79416691-1ccf6600-7f65-11ea-9097-1bcc5a31a9e2.png)
![Screen Shot 2020-04-15 at 10 03 51 PM](https://user-images.githubusercontent.com/35218/79416695-1f31c000-7f65-11ea-8e61-47bc706244e6.png)