### PR TITLE
Fix address validation rule to allow 'all' keyword

### DIFF
--- a/backend/schema/endpoints/access-lists.json
+++ b/backend/schema/endpoints/access-lists.json
@@ -35,7 +35,7 @@
 				},
 				{
 					"type": "string",
-					"pattern": "^any$"
+					"pattern": "^all$"
 				}
 			]
 		},


### PR DESCRIPTION
The rule was looking for the keyword 'any' but should have been looking for 'all' 

http://nginx.org/en/docs/http/ngx_http_access_module.html