### PR TITLE
Don't ask for username/password if none are defined

### DIFF
--- a/backend/internal/access-list.js
+++ b/backend/internal/access-list.js
@@ -71,7 +71,7 @@ const internalAccessList = {
 				// re-fetch with expansions
 				return internalAccessList.get(access, {
 					id:     data.id,
-					expand: ['owner', 'items', 'clients', 'proxy_hosts.access_list.clients']
+					expand: ['owner', 'items', 'clients', 'proxy_hosts.access_list.clients', 'proxy_hosts.access_list.items']
 				}, true /* <- skip masking */);
 			})
 			.then((row) => {
@@ -216,7 +216,7 @@ const internalAccessList = {
 				// re-fetch with expansions
 				return internalAccessList.get(access, {
 					id:     data.id,
-					expand: ['owner', 'items', 'clients', 'proxy_hosts.access_list.clients']
+					expand: ['owner', 'items', 'clients', 'proxy_hosts.access_list.clients', 'proxy_hosts.access_list.items']
 				}, true /* <- skip masking */);
 			})
 			.then((row) => {
@@ -254,7 +254,7 @@ const internalAccessList = {
 					.joinRaw('LEFT JOIN `proxy_host` ON `proxy_host`.`access_list_id` = `access_list`.`id` AND `proxy_host`.`is_deleted` = 0')
 					.where('access_list.is_deleted', 0)
 					.andWhere('access_list.id', data.id)
-					.allowEager('[owner,items,clients,proxy_hosts,proxy_hosts.access_list.clients]')
+					.allowEager('[owner,items,clients,proxy_hosts,proxy_hosts.access_list.clients,proxy_hosts.access_list.items]')
 					.omit(['access_list.is_deleted'])
 					.first();
 

--- a/backend/internal/proxy-host.js
+++ b/backend/internal/proxy-host.js
@@ -73,7 +73,7 @@ const internalProxyHost = {
 				// re-fetch with cert
 				return internalProxyHost.get(access, {
 					id:     row.id,
-					expand: ['certificate', 'owner', 'access_list.clients']
+					expand: ['certificate', 'owner', 'access_list.clients', 'access_list.items']
 				});
 			})
 			.then((row) => {
@@ -186,7 +186,7 @@ const internalProxyHost = {
 			.then(() => {
 				return internalProxyHost.get(access, {
 					id:     data.id,
-					expand: ['owner', 'certificate', 'access_list.clients']
+					expand: ['owner', 'certificate', 'access_list.clients', 'access_list.items']
 				})
 					.then((row) => {
 						// Configure nginx
@@ -219,7 +219,7 @@ const internalProxyHost = {
 					.query()
 					.where('is_deleted', 0)
 					.andWhere('id', data.id)
-					.allowEager('[owner,access_list,access_list.clients,certificate]')
+					.allowEager('[owner,access_list,access_list.clients,access_list.items,certificate]')
 					.first();
 
 				if (access_data.permission_visibility !== 'all') {

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -23,9 +23,11 @@ server {
   location / {
 
     {% if access_list_id > 0 %}
+    {% if access_list.items.length > 0 %}
     # Authorization
     auth_basic            "Authorization required";
     auth_basic_user_file  /data/access/{{ access_list_id }};
+    {% endif %}
 
     # Access Rules
     {% for client in access_list.clients %}


### PR DESCRIPTION
This commit optimizes the Nginx config implementation of an access list, preventing an auth-check if no users are actually defined.

This should still mean that creating an empty access rule results in an inaccessible site because of the default `deny all` rule (secure by default). But prevents Nginx from even processing Basic Auth, or asking for a username and password if there are no users to check against. 

~This PR also fixes a bug that was preventing Auth rules from being applied to a site after enabling a previously disabled site.~ (moved to #407)