### PR TITLE
set proper timeout.

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -26,12 +26,15 @@ http {
 	tcp_nopush                    on;
 	tcp_nodelay                   on;
 	client_body_temp_path         /tmp/nginx/body 1 2;
-	keepalive_timeout             65;
+	keepalive_timeout             90s;
+        proxy_connect_timeout         90s;
+        proxy_send_timeout            90s;
+        proxy_read_timeout            90s;
 	ssl_prefer_server_ciphers     on;
 	gzip                          on;
 	proxy_ignore_client_abort     off;
 	client_max_body_size          2000m;
-	server_names_hash_bucket_size 64;
+	server_names_hash_bucket_size 1024;
 	proxy_http_version            1.1;
 	proxy_set_header              X-Forwarded-Scheme $scheme;
 	proxy_set_header              X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
it makes so nginx can hangle connection client <- nginx -> backend for 90 secounds (90s i think is normal and most used timeout limit)

Example if you for backend have apache2 and your timeout is 300s and you try to install some script that take longer then 65s (current conf https://github.com/jc21/nginx-proxy-manager/blob/master/docker/rootfs/etc/nginx/nginx.conf#L29) then nginx will close connection at 65s ignoring apache (backend) 300s timeout and will return 504 err.

`server_names_hash_bucket_size 64;` **->** `server_names_hash_bucket_size 1024;` will increase support for long sub-domain names http://nginx.org/en/docs/http/server_names.html current 64 i think is low

