### PR TITLE
Fixed now_helper for sqlite (time is missing)

### DIFF
--- a/backend/models/now_helper.js
+++ b/backend/models/now_helper.js
@@ -6,7 +6,7 @@ Model.knex(db);
 
 module.exports = function () {
 	if (config.database.knex && config.database.knex.client === 'sqlite3') {
-		return Model.raw('date(\'now\')');
+		return Model.raw('datetime(\'now\',\'localtime\')');
 	} else {
 		return Model.raw('NOW()');
 	}


### PR DESCRIPTION
The sqlite `date('now')` function returns only the current time.
```
# echo "SELECT date('now')"|sqlite3
2020-08-06
```
To be comparable to the `NOW()` function of mysql, the date and time should be returned.  The `datetime('now','localtime')` function of sqlite does this:
```
# echo "SELECT datetime('now','localtime')"|sqlite3
2020-08-06 16:44:59
```
Which is the same thing as mysql:
```
# echo "SELECT NOW()"| mysql
NOW()
2020-08-06 16:44:59
```