### PR TITLE
Removed the hardcoded `--webroot` certbot argument to better support DNS challenge

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -733,7 +733,6 @@ const internalCertificate = {
 			'--agree-tos ' +
 			'--email "' + certificate.meta.letsencrypt_email + '" ' +
 			'--preferred-challenges "dns,http" ' +
-			'--webroot ' +
 			'--domains "' + certificate.domain_names.join(',') + '" ' +
 			(le_staging ? '--staging' : '');
 


### PR DESCRIPTION
Also, note that this option is already set in the default `letsencrypt.ini`.