### PR TITLE
Adds visual indicator for certificate deletion

### DIFF
--- a/frontend/js/app/nginx/certificates/delete.js
+++ b/frontend/js/app/nginx/certificates/delete.js
@@ -16,6 +16,8 @@ module.exports = Mn.View.extend({
     events: {
         'click @ui.save': function (e) {
             e.preventDefault();
+            this.ui.save.addClass('btn-loading');
+            this.ui.buttons.prop('disabled', true).addClass('btn-disabled');
 
             App.Api.Nginx.Certificates.delete(this.model.get('id'))
                 .then(() => {
@@ -25,6 +27,7 @@ module.exports = Mn.View.extend({
                 .catch(err => {
                     alert(err.message);
                     this.ui.buttons.prop('disabled', false).removeClass('btn-disabled');
+                    this.ui.save.removeClass('btn-loading');
                 });
         }
     }


### PR DESCRIPTION
This PR adds a spinner to the buttons at the confirm delete certificate dialog while it is processing in the background