### PR TITLE
Adds autoremove of failed certificate creations in DB

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -216,6 +216,13 @@ const internalCertificate = {
 											return saved_row;
 										});
 								});
+						}).catch(async (error) => {
+							// Delete the certificate from the database if it was not created successfully
+							await certificateModel
+								.query()
+								.deleteById(certificate.id);
+							
+							throw error;
 						});
 				} else {
 					return certificate;


### PR DESCRIPTION
This PR prevents certificates from showing up in the web interface when they failed to be created. No audit log is written, since nothing was changed. Up until now, an audit log entry was written, when the user had to manually delete the certificate, but when it was 'created', no log was written.

Fix https://github.com/jc21/nginx-proxy-manager/issues/629.