### PR TITLE
Allow nginx to resolve docker hostsnames

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -49,8 +49,8 @@ http {
 
 	access_log /data/logs/default.log proxy;
 
-	# Dynamically generated resolvers file
-	include /etc/nginx/conf.d/include/resolvers.conf;
+	# Used for resolving docker hosts
+	resolver 127.0.0.11;
 
 	# Default upstream scheme
 	map $host $forward_scheme {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1144171/100527835-90fa0980-31d6-11eb-8dd8-de5dcd1d70f5.png)

I've been unable to connect to docker hosts using their hostname even if they are on the same network. This fixes it by overriding the incorrect auto generated default value for the dns resolver. 

See: http://docs.docker.oeynet.com/engine/userguide/networking/configure-dns/
> Note: The DNS server is always at 127.0.0.11.

Fixes #203 
