### PR TITLE
Better custom certificate handling

### DIFF
--- a/frontend/js/app/nginx/certificates/form.ejs
+++ b/frontend/js/app/nginx/certificates/form.ejs
@@ -130,6 +130,9 @@
                 <% } else if (provider === 'other') { %>
                     <!-- Other -->
                     <div class="col-sm-12 col-md-12">
+                        <div class="text-blue mb-4"><i class="fe fe-alert-triangle"></i> <%= i18n('ssl', 'passphrase-protection-support-info') %></div>
+                    </div>
+                    <div class="col-sm-12 col-md-12">
                         <div class="form-group">
                             <label class="form-label"><%- i18n('str', 'name') %> <span class="form-required">*</span></label>
                             <input name="nice_name" type="text" class="form-control" placeholder="" value="<%- nice_name %>" required>

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -112,7 +112,8 @@
       "stored-as-plaintext-info": "This data will be stored as plaintext in the database and in a file!",
       "propagation-seconds": "Propagation Seconds",
       "propagation-seconds-info": "Leave empty to use the plugins default value. Number of seconds to wait for DNS propagation.",
-      "processing-info": "Processing... This might take a few minutes."
+      "processing-info": "Processing... This might take a few minutes.",
+      "passphrase-protection-support-info": "Key files protected with a passphrase are not supported."
     },
     "proxy-hosts": {
       "title": "Proxy Hosts",


### PR DESCRIPTION
This should fix https://github.com/jc21/nginx-proxy-manager/issues/594 and fix https://github.com/jc21/nginx-proxy-manager/issues/759.
Private key types are now no longer explicitly checked within proxy manager but instead it is outsourced to openssl. Furthermore a warning notifying the user, that passphrase protected keys are not supported was added, as well as an error thrown by the backend when the check timed out (which is usually because the command waits for the passphrase input).

This PR is in direct conflict with PR https://github.com/jc21/nginx-proxy-manager/pull/773