### PR TITLE
Prevent activating nginx config after editing disabled proxy host

### DIFF
--- a/backend/internal/proxy-host.js
+++ b/backend/internal/proxy-host.js
@@ -189,6 +189,10 @@ const internalProxyHost = {
 					expand: ['owner', 'certificate', 'access_list.[clients,items]']
 				})
 					.then((row) => {
+						if (!row.enabled) {
+							// No need to add nginx config if host is disabled
+							return row;
+						}
 						// Configure nginx
 						return internalNginx.configure(proxyHostModel, 'proxy_host', row)
 							.then((new_meta) => {


### PR DESCRIPTION

Check if proxy host is enabled and add an Nginx configuration only if the host is enabled to make sure it is consistent with the the db entry and the GUI

Fixes #290