### PR TITLE
Add ACME-DNS certbot plugin

### DIFF
--- a/global/certbot-dns-plugins.js
+++ b/global/certbot-dns-plugins.js
@@ -302,4 +302,14 @@ dns_eurodns_apiKey = mysecretpassword
 dns_eurodns_endpoint = https://rest-api.eurodns.com/user-api-gateway/proxy`,
 		full_plugin_name: 'certbot-dns-eurodns:dns-eurodns',
 	},
+	//####################################################//
+	acmedns: {
+		display_name:    'ACME-DNS',
+		package_name:    'certbot-dns-acmedns',
+		package_version: '0.1.0',
+		dependencies:    '',
+		credentials:     `certbot_dns_acmedns:dns_acmedns_api_url = http://acmedns-server/
+certbot_dns_acmedns:dns_acmedns_registration_file = /data/acme-registration.json`,
+		full_plugin_name: 'certbot-dns-acmedns:dns-acmedns',
+	},
 };


### PR DESCRIPTION
uses https://github.com/pan-net-security/certbot-dns-acmedns in to implement ACME-DNS support.
Requires file in /data with the following layout and permissions 600
```
# cat /data/acme-registration.json
{
  "something.acme.com": {
    "username": "6e14735c-2c6a-447e-b63d-a23ac4438bd7",
    "password": "dd6gnYS-IxrQfDLbdPRX3hrFhS_SLrwbS0kSl_i8",
    "fulldomain": "3b750a0e-c627-423f-9966-4799c6a9533b.auth.example.org",
    "subdomain": "3b750a0e-c627-423f-9966-4799c6a9533b",
    "allowfrom": []
  }
}
```

Follow setup at https://github.com/joohoi/acme-dns