### PR TITLE
Update _hsts.conf template to increase HSTS max-age value

### DIFF
--- a/backend/templates/_hsts.conf
+++ b/backend/templates/_hsts.conf
@@ -1,8 +1,8 @@
 {% if certificate and certificate_id > 0 -%}
 {% if ssl_forced == 1 or ssl_forced == true %}
 {% if hsts_enabled == 1 or hsts_enabled == true %}
-  # HSTS (ngx_http_headers_module is required) (31536000 seconds = 1 year)
-  add_header Strict-Transport-Security "max-age=31536000;{% if hsts_subdomains == 1 or hsts_subdomains == true -%} includeSubDomains;{% endif %} preload" always;
+  # HSTS (ngx_http_headers_module is required) (63072000 seconds = 2 years)
+  add_header Strict-Transport-Security "max-age=63072000;{% if hsts_subdomains == 1 or hsts_subdomains == true -%} includeSubDomains;{% endif %} preload" always;
 {% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
I propose the change of `max-age` value of HSTS from 1 year to 2 years in accordance with [Mozilla recommended configurations](https://wiki.mozilla.org/Security/Server_Side_TLS) for Security/Server side TLS.
- Recommended by Mozilla and security whitepapers
- Server side setting not affecting clients
- Security hardening principle
- 1 year fails most SSL checks
If variable value is necessary, I'd suggest an extra option in Proxy Host/SSL section in WebGUI.

Thank you and keep up the great work.