### PR TITLE
Apply 'Force SSL' and 'Enable Websockets' to full host definition

### DIFF
--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -5,6 +5,7 @@ server {
 {% include "_listen.conf" %}
 {% include "_certificates.conf" %}
 {% include "_hsts.conf" %}
+{% include "_forced_ssl.conf" %}
 
   access_log /data/logs/dead_host-{{ id }}.log standard;
 
@@ -12,7 +13,6 @@ server {
 
 {% if use_default_location %}
   location / {
-{% include "_forced_ssl.conf" %}
 {% include "_hsts.conf" %}
     return 404;
   }

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -11,6 +11,7 @@ server {
 {% include "_assets.conf" %}
 {% include "_exploits.conf" %}
 {% include "_hsts.conf" %}
+{% include "_forced_ssl.conf" %}
 
   access_log /data/logs/proxy_host-{{ id }}.log proxy;
 
@@ -43,7 +44,6 @@ server {
 
     {% endif %}
 
-{% include "_forced_ssl.conf" %}
 {% include "_hsts.conf" %}
 
     {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -13,6 +13,13 @@ server {
 {% include "_hsts.conf" %}
 {% include "_forced_ssl.conf" %}
 
+{% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $http_connection;
+proxy_http_version 1.1;
+{% endif %}
+
+
   access_log /data/logs/proxy_host-{{ id }}.log proxy;
 
 {{ advanced_config }}
@@ -45,12 +52,6 @@ server {
     {% endif %}
 
 {% include "_hsts.conf" %}
-
-    {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
-    proxy_http_version 1.1;
-    {% endif %}
 
     # Proxy!
     include conf.d/include/proxy.conf;

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -7,6 +7,7 @@ server {
 {% include "_assets.conf" %}
 {% include "_exploits.conf" %}
 {% include "_hsts.conf" %}
+{% include "_forced_ssl.conf" %}
 
   access_log /data/logs/redirection_host-{{ id }}.log standard;
 
@@ -14,7 +15,6 @@ server {
 
 {% if use_default_location %}
   location / {
-{% include "_forced_ssl.conf" %}
 {% include "_hsts.conf" %}
 
     {% if preserve_path == 1 or preserve_path == true %}


### PR DESCRIPTION
The template options for these two options have been moved out of the root location block, and into the server block, in order for them to apply to custom locations set up via the proxy manager. This matches up with default expectations of how these toggle options work (as they are defined in the frontend host definition rather than the location).

If override behaviour is desired, these options can still be overridden by the existing "custom options" support offered.