### PR TITLE
Vipergts450 custom location patch

### DIFF
--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -101,7 +101,7 @@ const internalNginx = {
 			logger.info('Testing Nginx configuration');
 		}
 
-		return utils.exec('/usr/sbin/nginx -t ');
+		return utils.exec('/usr/sbin/nginx -t -g "error_log off;"');
 	},
 
 	/**

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -156,11 +156,10 @@ const internalNginx = {
 			const locationRendering = async () => {
 				for (let i = 0; i < host.locations.length; i++) {
 					let locationCopy = Object.assign({}, {access_list_id: host.access_list_id}, {certificate_id: host.certificate_id}, 
-									{ssl_forced: host.ssl_forced}, {caching_enabled: host.caching_enabled}, 
-									{block_exploits: host.block_exploits}, {allow_websocket_upgrade: host.allow_websocket_upgrade}, 
-									{http2_support: host.http2_support}, {hsts_enabled: host.hsts_enabled}, 
-									{hsts_subdomains: host.hsts_subdomains}, {access_list: host.access_list},
-									{certificate: host.certificate}, host.locations[i]);
+						{ssl_forced: host.ssl_forced}, {caching_enabled: host.caching_enabled}, {block_exploits: host.block_exploits},
+						{allow_websocket_upgrade: host.allow_websocket_upgrade}, {http2_support: host.http2_support},
+						{hsts_enabled: host.hsts_enabled}, {hsts_subdomains: host.hsts_subdomains}, {access_list: host.access_list},
+						{certificate: host.certificate}, host.locations[i]);
 			
 					if (locationCopy.forward_host.indexOf('/') > -1) {
 						const splitted = locationCopy.forward_host.split('/');

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -137,7 +137,7 @@ const internalNginx = {
 	 */
 	renderLocations: (host) => {
 
-	//	logger.info('host = ' + JSON.stringify(host, null, 2));
+		//logger.info('host = ' + JSON.stringify(host, null, 2));
 		return new Promise((resolve, reject) => {
 			let template;
 
@@ -149,18 +149,18 @@ const internalNginx = {
 			}
 
 			let renderer          = new Liquid({
-                        	root: __dirname + '/../templates/'
-             		});
+				root: __dirname + '/../templates/'
+			});
 			let renderedLocations = '';
 
 			const locationRendering = async () => {
 				for (let i = 0; i < host.locations.length; i++) {
-					let locationCopy = Object.assign({}, {access_list_id : host.access_list_id}, {certificate_id : host.certificate_id}, 
-									{ssl_forced : host.ssl_forced}, {caching_enabled : host.caching_enabled}, 
-									{block_exploits : host.block_exploits}, {allow_websocket_upgrade : host.allow_websocket_upgrade}, 
-									{http2_support : host.http2_support}, {hsts_enabled : host.hsts_enabled}, 
-									{hsts_subdomains : host.hsts_subdomains}, {access_list : host.access_list},
-									{certificate : host.certificate}, host.locations[i]);
+					let locationCopy = Object.assign({}, {access_list_id: host.access_list_id}, {certificate_id: host.certificate_id}, 
+									{ssl_forced: host.ssl_forced}, {caching_enabled: host.caching_enabled}, 
+									{block_exploits: host.block_exploits}, {allow_websocket_upgrade: host.allow_websocket_upgrade}, 
+									{http2_support: host.http2_support}, {hsts_enabled: host.hsts_enabled}, 
+									{hsts_subdomains: host.hsts_subdomains}, {access_list: host.access_list},
+									{certificate: host.certificate}, host.locations[i]);
 			
 					if (locationCopy.forward_host.indexOf('/') > -1) {
 						const splitted = locationCopy.forward_host.split('/');
@@ -169,7 +169,7 @@ const internalNginx = {
 						locationCopy.forward_path = `/${splitted.join('/')}`;
 					}
 
-				//	logger.info('locationCopy = ' + JSON.stringify(locationCopy, null, 2));
+					//logger.info('locationCopy = ' + JSON.stringify(locationCopy, null, 2));
 
 					// eslint-disable-next-line
 					renderedLocations += await renderer.parseAndRender(template, locationCopy);
@@ -223,7 +223,7 @@ const internalNginx = {
 			}
 
 			if (host.locations) {
-		//		logger.info ('host.locations = ' + JSON.stringify(host.locations, null, 2));
+				//logger.info ('host.locations = ' + JSON.stringify(host.locations, null, 2));
 				origLocations    = [].concat(host.locations);
 				locationsPromise = internalNginx.renderLocations(host).then((renderedLocations) => {
 					host.locations = renderedLocations;

--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -101,7 +101,7 @@ const internalNginx = {
 			logger.info('Testing Nginx configuration');
 		}
 
-		return utils.exec('/usr/sbin/nginx -t -g "error_log off;"');
+		return utils.exec('/usr/sbin/nginx -t ');
 	},
 
 	/**
@@ -146,7 +146,9 @@ const internalNginx = {
 				return;
 			}
 
-			let renderer          = new Liquid();
+			let renderer          = new Liquid({
+                        	root: __dirname + '/../templates/'
+             		});
 			let renderedLocations = '';
 
 			const locationRendering = async () => {

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,8 +1,3 @@
-{% include "_assets.conf" %}
-{% include "_exploits.conf" %}
-{% include "_hsts.conf" %}
-
-
   location {{ path }} {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
@@ -10,7 +5,6 @@
     proxy_set_header X-Forwarded-For    $remote_addr;
     proxy_set_header X-Real-IP		$remote_addr;
     proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
-
 
     {% if access_list_id > 0 %}
     {% if access_list.items.length > 0 %}
@@ -33,6 +27,8 @@
  
     {% endif %}
 
+    {% include "_assets.conf" %}
+    {% include "_exploits.conf" %}
 
     {% include "_forced_ssl.conf" %}
     {% include "_hsts.conf" %}
@@ -46,3 +42,4 @@
 
     {{ advanced_config }}
   }
+

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -3,7 +3,40 @@
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-For    $remote_addr;
+    proxy_set_header X-Real-IP		$remote_addr;
     proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
+
+    {% if access_list_id > 0 %}
+    {% if access_list.items.length > 0 %}
+    # Authorization
+    auth_basic            "Authorization required";
+    auth_basic_user_file  /data/access/{{ access_list_id }};
+
+    {{ access_list.passauth }}
+    {% endif %}
+
+    # Access Rules
+    {% for client in access_list.clients %}
+    {{- client.rule -}};
+    {% endfor %}deny all;
+
+    # Access checks must...
+    {% if access_list.satisfy %}
+    {{ access_list.satisfy }};
+    {% endif %}
+
+    {% endif %}
+
+
+    {% include "_forced_ssl.conf" %}
+    {% include "_hsts.conf" %}
+
+    {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $http_connection;
+    proxy_http_version 1.1;
+    {% endif %}
+
+
     {{ advanced_config }}
   }
-

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,3 +1,8 @@
+{% include "_assets.conf" %}
+{% include "_exploits.conf" %}
+{% include "_hsts.conf" %}
+
+
   location {{ path }} {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
@@ -6,25 +11,26 @@
     proxy_set_header X-Real-IP		$remote_addr;
     proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
 
+
     {% if access_list_id > 0 %}
     {% if access_list.items.length > 0 %}
     # Authorization
     auth_basic            "Authorization required";
     auth_basic_user_file  /data/access/{{ access_list_id }};
-
+ 
     {{ access_list.passauth }}
     {% endif %}
-
+ 
     # Access Rules
     {% for client in access_list.clients %}
     {{- client.rule -}};
     {% endfor %}deny all;
-
+ 
     # Access checks must...
     {% if access_list.satisfy %}
     {{ access_list.satisfy }};
     {% endif %}
-
+ 
     {% endif %}
 
 


### PR DESCRIPTION
Possibly resolves jc21#148 jc21#590 but needs a lot of testing as I roughed this together. Probably can replace the top block with a modified
`include conf.d/include/proxy.conf;`

Allows custom locations to follow the rules set on the primary page such as Websockets, forcing SSL, HSTS, etc.

Made a couple of amendments to `/backend/templates/_location.conf` and `/backend/internal/nginx.js` to allow the custom location templates to have includes which should flesh out their configs and follow the settings of the main configuration page. Needs a lot of testing.