### PR TITLE
Improved new password error messages

### DIFF
--- a/frontend/js/app/user/password.ejs
+++ b/frontend/js/app/user/password.ejs
@@ -4,6 +4,7 @@
         <button type="button" class="close cancel" aria-label="Close" data-dismiss="modal">&nbsp;</button>
     </div>
     <div class="modal-body">
+        <div class="alert alert-danger" id="error-info" role="alert"></div>
         <form>
             <% if (isSelf()) { %>
             <div class="form-group">
@@ -15,7 +16,7 @@
             <div class="form-group">
                 <label class="form-label"><%- i18n('users', 'new-password') %></label>
                 <input type="password" name="new_password1" class="form-control" placeholder="" minlength="8" required>
-                <div class="invalid-feedback secret-error"></div>
+                <div class="invalid-feedback new-secret-error"></div>
             </div>
             <div class="form-group">
                 <label class="form-label"><%- i18n('users', 'confirm-password') %></label>

--- a/frontend/js/app/user/password.js
+++ b/frontend/js/app/user/password.js
@@ -9,21 +9,23 @@ module.exports = Mn.View.extend({
     className: 'modal-dialog',
 
     ui: {
-        form:    'form',
-        buttons: '.modal-footer button',
-        cancel:  'button.cancel',
-        save:    'button.save',
-        error:   '.secret-error'
+        form:           'form',
+        buttons:        '.modal-footer button',
+        cancel:         'button.cancel',
+        save:           'button.save',
+        newSecretError: '.new-secret-error',
+        generalError:   '#error-info',
     },
 
     events: {
         'click @ui.save': function (e) {
             e.preventDefault();
-            this.ui.error.hide();
+            this.ui.newSecretError.hide();
+            this.ui.generalError.hide();
             let form = this.ui.form.serializeJSON();
 
             if (form.new_password1 !== form.new_password2) {
-                this.ui.error.text('Passwords do not match!').show();
+                this.ui.newSecretError.text('Passwords do not match!').show();
                 return;
             }
 
@@ -40,7 +42,11 @@ module.exports = Mn.View.extend({
                     App.Controller.showUsers();
                 })
                 .catch(err => {
-                    this.ui.error.text(err.message).show();
+                    // Change error message to make it a little clearer
+                    if (err.message === 'Invalid password') {
+                        err.message = 'Current password is invalid';
+                    }
+                    this.ui.generalError.text(err.message).show();
                     this.ui.buttons.prop('disabled', false).removeClass('btn-disabled');
                 });
         }
@@ -54,5 +60,10 @@ module.exports = Mn.View.extend({
         return {
             isSelf: this.isSelf.bind(this)
         };
-    }
+    },
+
+    onRender: function () {
+        this.ui.newSecretError.hide();
+        this.ui.generalError.hide();
+    },
 });


### PR DESCRIPTION
Currently error messages like the current password being incorrect were shown just below the new password input field (see linked issue). However the  _Invalid password_ is just the error message directly from the backend, so it doesn't make sense to associate it with a specific form field at all.

In this PR there is a new error segment added at the very top. In there, all backend errors are now displayed.

Fixes https://github.com/jc21/nginx-proxy-manager/issues/1082.

![image](https://user-images.githubusercontent.com/26956711/117704127-045a6b00-b1ba-11eb-8197-5ad3deadf0ed.png)
