### PR TITLE
Displays entity id for each entry in frontend

### DIFF
--- a/frontend/js/app/nginx/access/list/item.ejs
+++ b/frontend/js/app/nginx/access/list/item.ejs
@@ -32,6 +32,7 @@
     <div class="item-action dropdown">
         <a href="#" data-toggle="dropdown" class="icon"><i class="fe fe-more-vertical"></i></a>
         <div class="dropdown-menu dropdown-menu-right">
+            <span class="dropdown-header"><%- i18n('audit-log', 'access-list') %> #<%- id %></span>
             <a href="#" class="edit dropdown-item"><i class="dropdown-icon fe fe-edit"></i> <%- i18n('str', 'edit') %></a>
             <div class="dropdown-divider"></div>
             <a href="#" class="delete dropdown-item"><i class="dropdown-icon fe fe-trash-2"></i> <%- i18n('str', 'delete') %></a>

--- a/frontend/js/app/nginx/certificates/list/item.ejs
+++ b/frontend/js/app/nginx/certificates/list/item.ejs
@@ -38,6 +38,7 @@
     <div class="item-action dropdown">
         <a href="#" data-toggle="dropdown" class="icon"><i class="fe fe-more-vertical"></i></a>
         <div class="dropdown-menu dropdown-menu-right">
+            <span class="dropdown-header"><%- i18n('audit-log', 'certificate') %> #<%- id %></span>
             <% if (provider === 'letsencrypt') { %>
                 <a href="#" class="renew dropdown-item"><i class="dropdown-icon fe fe-refresh-cw"></i> <%- i18n('certificates', 'force-renew') %></a>
                 <div class="dropdown-divider"></div>

--- a/frontend/js/app/nginx/dead/list/item.ejs
+++ b/frontend/js/app/nginx/dead/list/item.ejs
@@ -43,6 +43,7 @@
     <div class="item-action dropdown">
         <a href="#" data-toggle="dropdown" class="icon"><i class="fe fe-more-vertical"></i></a>
         <div class="dropdown-menu dropdown-menu-right">
+            <span class="dropdown-header"><%- i18n('audit-log', 'dead-host') %> #<%- id %></span>
             <a href="#" class="edit dropdown-item"><i class="dropdown-icon fe fe-edit"></i> <%- i18n('str', 'edit') %></a>
             <a href="#" class="able dropdown-item"><i class="dropdown-icon fe fe-power"></i> <%- i18n('str', enabled ? 'disable' : 'enable') %></a>
             <div class="dropdown-divider"></div>

--- a/frontend/js/app/nginx/proxy/list/item.ejs
+++ b/frontend/js/app/nginx/proxy/list/item.ejs
@@ -49,6 +49,7 @@
     <div class="item-action dropdown">
         <a href="#" data-toggle="dropdown" class="icon"><i class="fe fe-more-vertical"></i></a>
         <div class="dropdown-menu dropdown-menu-right">
+            <span class="dropdown-header"><%- i18n('audit-log', 'proxy-host') %> #<%- id %></span>
             <a href="#" class="edit dropdown-item"><i class="dropdown-icon fe fe-edit"></i> <%- i18n('str', 'edit') %></a>
             <a href="#" class="able dropdown-item"><i class="dropdown-icon fe fe-power"></i> <%- i18n('str', enabled ? 'disable' : 'enable') %></a>
             <div class="dropdown-divider"></div>

--- a/frontend/js/app/nginx/redirection/list/item.ejs
+++ b/frontend/js/app/nginx/redirection/list/item.ejs
@@ -52,6 +52,7 @@
     <div class="item-action dropdown">
         <a href="#" data-toggle="dropdown" class="icon"><i class="fe fe-more-vertical"></i></a>
         <div class="dropdown-menu dropdown-menu-right">
+            <span class="dropdown-header"><%- i18n('audit-log', 'redirection-host') %> #<%- id %></span>
             <a href="#" class="edit dropdown-item"><i class="dropdown-icon fe fe-edit"></i> <%- i18n('str', 'edit') %></a>
             <a href="#" class="able dropdown-item"><i class="dropdown-icon fe fe-power"></i> <%- i18n('str', enabled ? 'disable' : 'enable') %></a>
             <div class="dropdown-divider"></div>

--- a/frontend/js/app/nginx/stream/list/item.ejs
+++ b/frontend/js/app/nginx/stream/list/item.ejs
@@ -42,6 +42,7 @@
     <div class="item-action dropdown">
         <a href="#" data-toggle="dropdown" class="icon"><i class="fe fe-more-vertical"></i></a>
         <div class="dropdown-menu dropdown-menu-right">
+            <span class="dropdown-header"><%- i18n('audit-log', 'stream') %> #<%- id %></span>
             <a href="#" class="edit dropdown-item"><i class="dropdown-icon fe fe-edit"></i> <%- i18n('str', 'edit') %></a>
             <a href="#" class="able dropdown-item"><i class="dropdown-icon fe fe-power"></i> <%- i18n('str', enabled ? 'disable' : 'enable') %></a>
             <div class="dropdown-divider"></div>

--- a/frontend/js/app/users/list/item.ejs
+++ b/frontend/js/app/users/list/item.ejs
@@ -29,6 +29,7 @@
     <div class="item-action dropdown">
         <a href="#" data-toggle="dropdown" class="icon"><i class="fe fe-more-vertical"></i></a>
         <div class="dropdown-menu dropdown-menu-right">
+            <span class="dropdown-header"><%- i18n('audit-log', 'user') %> #<%- id %></span>
             <a href="#" class="edit-user dropdown-item"><i class="dropdown-icon fe fe-edit"></i> <%- i18n('users', 'edit-details') %></a>
             <a href="#" class="edit-permissions dropdown-item"><i class="dropdown-icon fe fe-shield"></i> <%- i18n('users', 'edit-permissions') %></a>
             <a href="#" class="set-password dropdown-item"><i class="dropdown-icon fe fe-lock"></i> <%- i18n('users', 'change-password') %></a>

--- a/frontend/scss/custom.scss
+++ b/frontend/scss/custom.scss
@@ -12,6 +12,10 @@ a:hover {
     color: darken($primary-color, 10%);
 }
 
+.dropdown-header {
+    padding-left: 1rem;
+}
+
 .dropdown-item.active, .dropdown-item:active {
     background-color: $primary-color;
 }


### PR DESCRIPTION
In this PR the entity ids are displayed inside the three-dot-menu on the right:

![image](https://user-images.githubusercontent.com/26956711/118401962-415dac00-b657-11eb-9aff-680cd9a05a49.png)

This is for all entities which are displayed in a table:

- Certificates
- Proxy Hosts
- 404 Hosts
- Redirection Hosts
- Streams
- Users
- Access Lists

Though the last two are not that relevant it probably won't hurt either.

Resolves https://github.com/jc21/nginx-proxy-manager/issues/174
