### PR TITLE
Fixes some database issues on raspberry pi

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -95,7 +95,8 @@ async function createDbConfigFromEnvironment() {
 						client:     'sqlite3',
 						connection: {
 							filename: envSqliteFile
-						}
+						},
+						useNullAsDefault: true
 					}
 				};
 				if (JSON.stringify(configData.database) === JSON.stringify(newConfig)) {

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -122,18 +122,15 @@ services:
     depends_on:
       - db
   db:
-    image: ghcr.io/linuxserver/mariadb
+    image: yobasystems/alpine-mariadb:latest
     restart: unless-stopped
     environment:
-      PUID: 1001
-      PGID: 1001
-      TZ: "Europe/London"
       MYSQL_ROOT_PASSWORD: "changeme"
       MYSQL_DATABASE: "npm"
       MYSQL_USER: "changeuser"
       MYSQL_PASSWORD: "changepass"
     volumes:
-      - ./data/mariadb:/config
+      - ./data/mariadb:/var/lib/mysql
 ```
 
 _Please note, that `DB_MYSQL_*` environment variables will take precedent over `DB_SQLITE_*` var>

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -185,7 +185,8 @@ Here's an example for `sqlite` configuration as it is generated from the environ
       "client": "sqlite3",
       "connection": {
         "filename": "/data/database.sqlite"
-      }
+      },
+      "useNullAsDefault": true
     }
   }
 }


### PR DESCRIPTION
- Resolves https://github.com/jc21/nginx-proxy-manager/issues/700
- Resolves https://github.com/jc21/nginx-proxy-manager/issues/212

I tested both the new db image and sqlite database on an x86 computer, and it still works, so this shouldn't break non-pi installations.