### PR TITLE
Adds logrotation

### DIFF
--- a/backend/setup.js
+++ b/backend/setup.js
@@ -210,7 +210,7 @@ const setupLogrotation = () => {
 	const intervalTimeout = 1000 * 60 * 60 * 24 * 2; // 2 days
 
 	const runLogrotate = async () => {
-		await utils.exec('logrotate -f /etc/logrotate.d/nginx-proxy-manager');
+		await utils.exec('logrotate /etc/logrotate.d/nginx-proxy-manager');
 		logger.info('Logrotate completed.');
 	};
 

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -201,9 +201,29 @@ const setupCertbotPlugins = () => {
 		});
 };
 
+
+/**
+ * Starts a timer to call run the logrotation binary every two days
+ * @returns {Promise}
+ */
+const setupLogrotation = () => {
+	const intervalTimeout = 1000 * 60 * 60 * 24 * 2; // 2 days
+
+	const runLogrotate = async () => {
+		await utils.exec('logrotate -f /etc/logrotate.d/nginx-proxy-manager');
+		logger.info('Logrotate completed.');
+	};
+
+	logger.info('Logrotate Timer initialized');
+	setInterval(runLogrotate, intervalTimeout);
+	// And do this now as well
+	return runLogrotate();
+};
+
 module.exports = function () {
 	return setupJwt()
 		.then(setupDefaultUser)
 		.then(setupDefaultSettings)
-		.then(setupCertbotPlugins);
+		.then(setupCertbotPlugins)
+		.then(setupLogrotation);
 };

--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -7,7 +7,8 @@ server {
 {% include "_hsts.conf" %}
 {% include "_forced_ssl.conf" %}
 
-  access_log /data/logs/dead_host-{{ id }}.log standard;
+  access_log /data/logs/dead-host-{{ id }}_access.log standard;
+  error_log /data/logs/dead-host-{{ id }}_error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -7,8 +7,8 @@ server {
 {% include "_hsts.conf" %}
 {% include "_forced_ssl.conf" %}
 
-  access_log /data/logs/dead_host-{{ id }}/access.log standard;
-  error_log /data/logs/dead_host-{{ id }}/error.log warn;
+  access_log /data/logs/dead-host-{{ id }}_access.log standard;
+  error_log /data/logs/dead-host-{{ id }}_error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/dead_host.conf
+++ b/backend/templates/dead_host.conf
@@ -7,8 +7,8 @@ server {
 {% include "_hsts.conf" %}
 {% include "_forced_ssl.conf" %}
 
-  access_log /data/logs/dead-host-{{ id }}_access.log standard;
-  error_log /data/logs/dead-host-{{ id }}_error.log warn;
+  access_log /data/logs/dead_host-{{ id }}/access.log standard;
+  error_log /data/logs/dead_host-{{ id }}/error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/default.conf
+++ b/backend/templates/default.conf
@@ -12,7 +12,8 @@ server {
   #listen [::]:80;
 {% endif %}
   server_name default-host.localhost;
-  access_log /data/logs/default_host.log combined;
+  access_log /data/logs/default-host_access.log combined;
+  error_log /data/logs/default-host_error.log warn;
 {% include "_exploits.conf" %}
 
 {%- if value == "404" %}

--- a/backend/templates/default.conf
+++ b/backend/templates/default.conf
@@ -12,8 +12,8 @@ server {
   #listen [::]:80;
 {% endif %}
   server_name default-host.localhost;
-  access_log /data/logs/default-host_access.log combined;
-  error_log /data/logs/default-host_error.log warn;
+  access_log /data/logs/default_host/access.log combined;
+  error_log /data/logs/default_host/error.log warn;
 {% include "_exploits.conf" %}
 
 {%- if value == "404" %}

--- a/backend/templates/default.conf
+++ b/backend/templates/default.conf
@@ -12,8 +12,8 @@ server {
   #listen [::]:80;
 {% endif %}
   server_name default-host.localhost;
-  access_log /data/logs/default_host/access.log combined;
-  error_log /data/logs/default_host/error.log warn;
+  access_log /data/logs/default-host_access.log combined;
+  error_log /data/logs/default-host_error.log warn;
 {% include "_exploits.conf" %}
 
 {%- if value == "404" %}

--- a/backend/templates/letsencrypt-request.conf
+++ b/backend/templates/letsencrypt-request.conf
@@ -8,7 +8,8 @@ server {
 
   server_name {{ domain_names | join: " " }};
 
-  access_log /data/logs/letsencrypt-requests.log standard;
+  access_log /data/logs/letsencrypt-requests_access.log standard;
+  error_log /data/logs/letsencrypt-requests_error.log warn;
 
   include conf.d/include/letsencrypt-acme-challenge.conf;
 

--- a/backend/templates/letsencrypt-request.conf
+++ b/backend/templates/letsencrypt-request.conf
@@ -8,8 +8,8 @@ server {
 
   server_name {{ domain_names | join: " " }};
 
-  access_log /data/logs/letsencrypt-requests_access.log standard;
-  error_log /data/logs/letsencrypt-requests_error.log warn;
+  access_log /data/logs/letsencrypt_requests/access.log standard;
+  error_log /data/logs/letsencrypt_requests/error.log warn;
 
   include conf.d/include/letsencrypt-acme-challenge.conf;
 

--- a/backend/templates/letsencrypt-request.conf
+++ b/backend/templates/letsencrypt-request.conf
@@ -8,8 +8,8 @@ server {
 
   server_name {{ domain_names | join: " " }};
 
-  access_log /data/logs/letsencrypt_requests/access.log standard;
-  error_log /data/logs/letsencrypt_requests/error.log warn;
+  access_log /data/logs/letsencrypt-requests_access.log standard;
+  error_log /data/logs/letsencrypt-requests_error.log warn;
 
   include conf.d/include/letsencrypt-acme-challenge.conf;
 

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -19,8 +19,8 @@ proxy_set_header Connection $http_connection;
 proxy_http_version 1.1;
 {% endif %}
 
-
-  access_log /data/logs/proxy_host-{{ id }}.log proxy;
+  access_log /data/logs/proxy-host-{{ id }}_access.log proxy;
+  error_log /data/logs/proxy-host-{{ id }}_error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -19,8 +19,8 @@ proxy_set_header Connection $http_connection;
 proxy_http_version 1.1;
 {% endif %}
 
-  access_log /data/logs/proxy_host-{{ id }}/access.log proxy;
-  error_log /data/logs/proxy_host-{{ id }}/error.log warn;
+  access_log /data/logs/proxy-host-{{ id }}_access.log proxy;
+  error_log /data/logs/proxy-host-{{ id }}_error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -19,8 +19,8 @@ proxy_set_header Connection $http_connection;
 proxy_http_version 1.1;
 {% endif %}
 
-  access_log /data/logs/proxy-host-{{ id }}_access.log proxy;
-  error_log /data/logs/proxy-host-{{ id }}_error.log warn;
+  access_log /data/logs/proxy_host-{{ id }}/access.log proxy;
+  error_log /data/logs/proxy_host-{{ id }}/error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -9,7 +9,8 @@ server {
 {% include "_hsts.conf" %}
 {% include "_forced_ssl.conf" %}
 
-  access_log /data/logs/redirection_host-{{ id }}.log standard;
+  access_log /data/logs/redirection-host-{{ id }}_access.log standard;
+  error_log /data/logs/redirection-host-{{ id }}_error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -9,8 +9,8 @@ server {
 {% include "_hsts.conf" %}
 {% include "_forced_ssl.conf" %}
 
-  access_log /data/logs/redirection_host-{{ id }}/access.log standard;
-  error_log /data/logs/redirection_host-{{ id }}/error.log warn;
+  access_log /data/logs/redirection-host-{{ id }}_access.log standard;
+  error_log /data/logs/redirection-host-{{ id }}_error.log warn;
 
 {{ advanced_config }}
 

--- a/backend/templates/redirection_host.conf
+++ b/backend/templates/redirection_host.conf
@@ -9,8 +9,8 @@ server {
 {% include "_hsts.conf" %}
 {% include "_forced_ssl.conf" %}
 
-  access_log /data/logs/redirection-host-{{ id }}_access.log standard;
-  error_log /data/logs/redirection-host-{{ id }}_error.log warn;
+  access_log /data/logs/redirection_host-{{ id }}/access.log standard;
+  error_log /data/logs/redirection_host-{{ id }}/error.log warn;
 
 {{ advanced_config }}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ENV SUPPRESS_NO_CONFIG_WARNING=1 \
 
 RUN echo "fs.file-max = 65535" > /etc/sysctl.conf \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends jq \
+	&& apt-get install -y --no-install-recommends jq logrotate \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -42,6 +42,9 @@ COPY docker/rootfs /
 
 # Remove frontend service not required for prod, dev nginx config as well
 RUN rm -rf /etc/services.d/frontend /etc/nginx/conf.d/dev.conf
+
+# Change permission of logrotate config file
+RUN chmod 644 /etc/logrotate.d/nginx-proxy-manager
 
 VOLUME [ "/data", "/etc/letsencrypt" ]
 ENTRYPOINT [ "/init" ]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -7,7 +7,7 @@ ENV S6_LOGGING=0 \
 
 RUN echo "fs.file-max = 65535" > /etc/sysctl.conf \
 	&& apt-get update \
-	&& apt-get install -y certbot jq python3-pip \
+	&& apt-get install -y certbot jq python3-pip logrotate \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -18,6 +18,7 @@ RUN cd /usr \
 
 COPY rootfs /
 RUN rm -f /etc/nginx/conf.d/production.conf
+RUN chmod 644 /etc/logrotate.d/nginx-proxy-manager
 
 # s6 overlay
 RUN curl -L -o /tmp/s6-overlay-amd64.tar.gz "https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz" \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,9 +1,9 @@
 # WARNING: This is a DEVELOPMENT docker-compose file, it should not be used for production.
-version: "3"
+version: "3.5"
 services:
-
   npm:
     image: nginxproxymanager:dev
+    container_name: npm_core
     build:
       context: ./
       dockerfile: ./dev/Dockerfile
@@ -36,6 +36,7 @@ services:
 
   db:
     image: jc21/mariadb-aria
+    container_name: npm_db
     networks:
       - nginx_proxy_manager
     environment:
@@ -47,21 +48,26 @@ services:
       - db_data:/var/lib/mysql
 
   swagger:
-    image: 'swaggerapi/swagger-ui:latest'
+    image: "swaggerapi/swagger-ui:latest"
+    container_name: npm_swagger
     ports:
       - 3001:80
     networks:
       - nginx_proxy_manager
     environment:
       URL: "http://127.0.0.1:3081/api/schema"
-      PORT: '80'
+      PORT: "80"
     depends_on:
       - npm
 
 volumes:
   npm_data:
+    name: npm_core_data
   le_data:
+    name: npm_le_data
   db_data:
+    name: npm_db_data
 
 networks:
   nginx_proxy_manager:
+    name: npm_network

--- a/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
+++ b/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
@@ -1,0 +1,25 @@
+/data/logs/*_access.log /data/logs/*/*_access.log {
+    create 0644 root root
+    weekly
+    rotate 4
+    missingok
+    notifempty
+    compress
+    sharedscripts
+    postrotate
+    /bin/kill -USR1 `cat /run/nginx.pid 2>/dev/null` 2>/dev/null || true
+    endscript
+}
+
+/data/logs/*_error.log /data/logs/*/*_error.log {
+    create 0644 root root
+    weekly
+    rotate 10
+    missingok
+    notifempty
+    compress
+    sharedscripts
+    postrotate
+    /bin/kill -USR1 `cat /run/nginx.pid 2>/dev/null` 2>/dev/null || true
+    endscript
+}

--- a/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
+++ b/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
@@ -23,3 +23,16 @@
     /bin/kill -USR1 `cat /run/nginx.pid 2>/dev/null` 2>/dev/null || true
     endscript
 }
+
+/data/logs/*.log /data/logs/*[!_error].log /data/logs/*[!_access].log {
+    create 0644 root root
+    weekly
+    rotate 5
+    missingok
+    notifempty
+    compress
+    sharedscripts
+    postrotate
+    /bin/kill -USR1 `cat /run/nginx.pid 2>/dev/null` 2>/dev/null || true
+    endscript
+}

--- a/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
+++ b/docker/rootfs/etc/logrotate.d/nginx-proxy-manager
@@ -1,4 +1,4 @@
-/data/logs/*_access.log /data/logs/*/*_access.log {
+/data/logs/*_access.log /data/logs/*/access.log {
     create 0644 root root
     weekly
     rotate 4
@@ -11,23 +11,10 @@
     endscript
 }
 
-/data/logs/*_error.log /data/logs/*/*_error.log {
+/data/logs/*_error.log /data/logs/*/error.log {
     create 0644 root root
     weekly
     rotate 10
-    missingok
-    notifempty
-    compress
-    sharedscripts
-    postrotate
-    /bin/kill -USR1 `cat /run/nginx.pid 2>/dev/null` 2>/dev/null || true
-    endscript
-}
-
-/data/logs/*.log /data/logs/*[!_error].log /data/logs/*[!_access].log {
-    create 0644 root root
-    weekly
-    rotate 5
     missingok
     notifempty
     compress

--- a/docker/rootfs/etc/nginx/conf.d/default.conf
+++ b/docker/rootfs/etc/nginx/conf.d/default.conf
@@ -8,7 +8,7 @@ server {
 	set $port "80";
 
 	server_name localhost-nginx-proxy-manager;
-	access_log /data/logs/default.log standard;
+	access_log /data/logs/fallback-access.log standard;
 	error_log /dev/null crit;
 	include conf.d/include/assets.conf;
 	include conf.d/include/block-exploits.conf;
@@ -29,7 +29,7 @@ server {
 	set $port "443";
 
 	server_name localhost;
-	access_log /data/logs/default.log standard;
+	access_log /data/logs/fallback-access.log standard;
 	error_log /dev/null crit;
 	ssl_certificate /data/nginx/dummycert.pem;
 	ssl_certificate_key /data/nginx/dummykey.pem;

--- a/docker/rootfs/etc/nginx/conf.d/default.conf
+++ b/docker/rootfs/etc/nginx/conf.d/default.conf
@@ -8,7 +8,7 @@ server {
 	set $port "80";
 
 	server_name localhost-nginx-proxy-manager;
-	access_log /data/logs/fallback-access.log standard;
+	access_log /data/logs/fallback_access.log standard;
 	error_log /dev/null crit;
 	include conf.d/include/assets.conf;
 	include conf.d/include/block-exploits.conf;

--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -9,7 +9,7 @@ worker_processes auto;
 # Enables the use of JIT for regular expressions to speed-up their processing.
 pcre_jit on;
 
-error_log /data/logs/fallback-error.log warn;
+error_log /data/logs/fallback_error.log warn;
 
 # Includes files with directives to load dynamic modules.
 include /etc/nginx/modules/*.conf;
@@ -46,7 +46,7 @@ http {
 	log_format proxy '[$time_local] $upstream_cache_status $upstream_status $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] [Sent-to $server] "$http_user_agent" "$http_referer"';
 	log_format standard '[$time_local] $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] "$http_user_agent" "$http_referer"';
 
-	access_log /data/logs/fallback-access.log proxy;
+	access_log /data/logs/fallback_access.log proxy;
 
 	# Dynamically generated resolvers file
 	include /etc/nginx/conf.d/include/resolvers.conf;

--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -9,7 +9,7 @@ worker_processes auto;
 # Enables the use of JIT for regular expressions to speed-up their processing.
 pcre_jit on;
 
-error_log /data/logs/error.log warn;
+error_log /data/logs/fallback-error.log warn;
 
 # Includes files with directives to load dynamic modules.
 include /etc/nginx/modules/*.conf;
@@ -46,8 +46,7 @@ http {
 	log_format proxy '[$time_local] $upstream_cache_status $upstream_status $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] [Sent-to $server] "$http_user_agent" "$http_referer"';
 	log_format standard '[$time_local] $status - $request_method $scheme $host "$request_uri" [Client $remote_addr] [Length $body_bytes_sent] [Gzip $gzip_ratio] "$http_user_agent" "$http_referer"';
 
-
-	access_log /data/logs/default.log proxy;
+	access_log /data/logs/fallback-access.log proxy;
 
 	# Dynamically generated resolvers file
 	include /etc/nginx/conf.d/include/resolvers.conf;


### PR DESCRIPTION
This PR adds logrotation to the access and error logs of the hosts. both are rotated weekly. For access logs the last 4 files (=4 weeks) are kept, for error logs the last 10 files are kept.

Running performing the dry-run with
```
logrotate -d /etc/logrotate.d/nginx-proxy-manager
```

seems to work as expected, however we will have to wait to see if it actually does everything as expected.

Fixes https://github.com/jc21/nginx-proxy-manager/issues/183.