### PR TITLE
Sets real_ip ranges to local network only

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -58,11 +58,11 @@ http {
 	}
 
 	# Real IP Determination
-	# Docker subnet:
-	set_real_ip_from 172.0.0.0/8;
+	
 	# Local subnets:
 	set_real_ip_from 10.0.0.0/8;
-	set_real_ip_from 192.0.0.0/8;
+	set_real_ip_from 172.16.0.0/12; # Includes Docker subnet
+	set_real_ip_from 192.168.0.0/16;
 	# NPM generated CDN ip ranges:
 	include conf.d/include/ip_ranges.conf;
 	# always put the following 2 lines after ip subnets:


### PR DESCRIPTION
Makes sure the real_ip ranges only include trusted IP addresses from [local subnets](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses)