### PR TITLE
Fix wildcard domain regex

### DIFF
--- a/frontend/js/app/nginx/certificates/form.js
+++ b/frontend/js/app/nginx/certificates/form.js
@@ -251,7 +251,7 @@ module.exports = Mn.View.extend({
                     text:  input
                 };
             },
-            createFilter: /^(?:[^.]+\.?)+[^.]$/
+            createFilter: /^(?:\*\.)?(?:[^.*]+\.?)+[^.]$/
         });
         this.ui.dns_challenge_content.hide();
         this.ui.credentials_file_content.hide(); 

--- a/frontend/js/app/nginx/proxy/form.js
+++ b/frontend/js/app/nginx/proxy/form.js
@@ -278,7 +278,7 @@ module.exports = Mn.View.extend({
                     text:  input
                 };
             },
-            createFilter: /^(?:\.)?(?:[^.*]+\.?)+[^.]$/
+            createFilter: /^(?:\*\.)?(?:[^.*]+\.?)+[^.]$/
         });
 
         // Access Lists


### PR DESCRIPTION
Hi,
I was trying to use wildcard domain on proxy host (`*.example.org`) but the frontend didn't respond how I wanted. 

![100749548-85098400-3430-11eb-8c01-74eafed92737](https://user-images.githubusercontent.com/58510131/122375649-b593b400-cf63-11eb-9927-1b3c1f4903c8.png)

After a quick search in the code, it seem that the bug was introduce during #572 .
I found an open issue for this bug #749 .
I just changed the regex to match wildcard domain on proxy host like it is doing on dead and redirection host. I changed the wildcard certification regex too to match all the other.

It now works like a charm !