### PR TITLE
Use the certbot command from the PATH variable

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -11,7 +11,7 @@ const debug_mode       = process.env.NODE_ENV !== 'production' || !!process.env.
 const le_staging       = process.env.NODE_ENV !== 'production';
 const internalNginx    = require('./nginx');
 const internalHost     = require('./host');
-const certbot_command  = '/opt/certbot/bin/certbot';
+const certbot_command  = 'certbot';
 const le_config        = '/etc/letsencrypt.ini';
 const dns_plugins      = require('../global/certbot-dns-plugins');
 


### PR DESCRIPTION
To fix https://github.com/jc21/nginx-proxy-manager/issues/1109, the path to the certbot command should not be hard-coded, but instead be taken from $PATH.  
Since it is only used inside `certificate.js` it is easy to validate. The certbot command is only used as a paramerter for `utils.exec()`, which in turn uses `child_process.exec()`, which does look up the commands in PATH.