### PR TITLE
Disable auth_request in letsencrypt-acme-challenge.conf

### DIFF
--- a/docker/rootfs/etc/nginx/conf.d/include/letsencrypt-acme-challenge.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/letsencrypt-acme-challenge.conf
@@ -5,6 +5,7 @@ location ^~ /.well-known/acme-challenge/ {
 	# Since this is for letsencrypt authentication of a domain and they do not give IP ranges of their infrastructure
 	# we need to open up access by turning off auth and IP ACL for this location.
 	auth_basic off;
+	auth_request off;
 	allow all;
 
 	# Set correct content type. According to this:


### PR DESCRIPTION
Proxy hosts using the auth_request feature will, without this addition to letsencrypt-acme-challenge.conf, be unable to renew their certificates. This disables auth_request (as it already did for auth_basic) for the acme-challenge directory to allow for renewals without issue.