### PR TITLE
Fixes crash when logrotate fails

### DIFF
--- a/backend/setup.js
+++ b/backend/setup.js
@@ -210,8 +210,10 @@ const setupLogrotation = () => {
 	const intervalTimeout = 1000 * 60 * 60 * 24 * 2; // 2 days
 
 	const runLogrotate = async () => {
-		await utils.exec('logrotate /etc/logrotate.d/nginx-proxy-manager');
-		logger.info('Logrotate completed.');
+		try {
+			await utils.exec('logrotate /etc/logrotate.d/nginx-proxy-manager');
+			logger.info('Logrotate completed.');
+		} catch (e) { logger.warn(e); }
 	};
 
 	logger.info('Logrotate Timer initialized');

--- a/docker/rootfs/etc/cont-init.d/01_perms.sh
+++ b/docker/rootfs/etc/cont-init.d/01_perms.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+mkdir -p /data/logs
+chown -R root:root /data/logs


### PR DESCRIPTION
Fixes https://github.com/jc21/nginx-proxy-manager/issues/1250
Somehow the owner of the logs is sometimes not root, which causes logrotate to fail. This makes sure that a failing of logrotate does not crash npm.