### PR TITLE
Utilise variable for custom locations proxy_pass

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,10 +1,11 @@
   location {{ path }} {
+    set              $upstream {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-For    $remote_addr;
     proxy_set_header X-Real-IP		$remote_addr;
-    proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
+    proxy_pass       $upstream;
 
     {% if access_list_id > 0 %}
     {% if access_list.items.length > 0 %}


### PR DESCRIPTION
If a custom location is currently set to proxy to a DNS hostname this hostname is cached by nginx. When the underlying IP for the hostname changes this will be cached in nginx until it is restarted. This behaviour is somewhat undesirable if utilising containers.

This change sets the proxy_pass for custom locations into a variable and utilises said variable for routing to the upstream backend. This will ensure that nginx will utilise the resolver and resolve the hostname to the current IP instead of relying on the nginx cache.