### PR TITLE
Update letsencrypt.ini to support ECDSA keys

### DIFF
--- a/docker/rootfs/etc/letsencrypt.ini
+++ b/docker/rootfs/etc/letsencrypt.ini
@@ -2,3 +2,5 @@ text = True
 non-interactive = True
 authenticator = webroot
 webroot-path = /data/letsencrypt-acme-challenge
+key-type = ecdsa
+elliptic-curve = secp384r1


### PR DESCRIPTION
Since we have newer certbot (1.10+) available (thanks!), it's time to support more modern, safer and efficient ECDSA private keys algorithms instead of RSA for the generated certificates. EC secp384r1 would need 7680bit RSA equivalent for comparable security with significantly higher overhead.

These should be now widely supported by all modern browsers and service clients. The only risk would be sudden certbot downgrade, which can be controlled.

I propose this should be now default.