### PR TITLE
Fixes certificate renewal

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -758,6 +758,7 @@ const internalCertificate = {
 	},
 
 	/**
+	 * Request a certificate using the http challenge
 	 * @param   {Object}  certificate   the certificate row
 	 * @returns {Promise}
 	 */
@@ -768,6 +769,7 @@ const internalCertificate = {
 			'--config "' + letsencryptConfig + '" ' +
 			'--cert-name "npm-' + certificate.id + '" ' +
 			'--agree-tos ' +
+			'--authenticator webroot ' +
 			'--email "' + certificate.meta.letsencrypt_email + '" ' +
 			'--preferred-challenges "dns,http" ' +
 			'--domains "' + certificate.domain_names.join(',') + '" ' +

--- a/backend/templates/default.conf
+++ b/backend/templates/default.conf
@@ -16,6 +16,8 @@ server {
   error_log /data/logs/default-host_error.log warn;
 {% include "_exploits.conf" %}
 
+  include conf.d/include/letsencrypt-acme-challenge.conf;
+
 {%- if value == "404" %}
   location / {
     return 404;

--- a/docker/rootfs/etc/letsencrypt.ini
+++ b/docker/rootfs/etc/letsencrypt.ini
@@ -1,4 +1,3 @@
 text = True
 non-interactive = True
-authenticator = webroot
 webroot-path = /data/letsencrypt-acme-challenge

--- a/docker/rootfs/etc/nginx/conf.d/default.conf
+++ b/docker/rootfs/etc/nginx/conf.d/default.conf
@@ -9,9 +9,10 @@ server {
 
 	server_name localhost-nginx-proxy-manager;
 	access_log /data/logs/fallback_access.log standard;
-	error_log /dev/null crit;
+	error_log /data/logs/fallback_error.log warn;
 	include conf.d/include/assets.conf;
 	include conf.d/include/block-exploits.conf;
+	include conf.d/include/letsencrypt-acme-challenge.conf;
 
 	location / {
 		index index.html;


### PR DESCRIPTION
This will fix the certificate renewal in some cases:

- Automatic renewal using DNS challenges used to always fail due to the authenticator being overwritten globally
- Automatic renewal using the HTTP challenge used to fail if the domain was not used in any host. 

This PR removes the global authenticator being set, since it is always set certificate specific as well, and adds the letsencrypt challenge functionality to the default host (using any of the congratulations site, 404 page, redirect or custom page)

Should fix https://github.com/jc21/nginx-proxy-manager/issues/1282, probably fixes https://github.com/jc21/nginx-proxy-manager/issues/1220, fixes https://github.com/jc21/nginx-proxy-manager/issues/1031, should fix https://github.com/jc21/nginx-proxy-manager/issues/1018 and fixes https://github.com/jc21/nginx-proxy-manager/issues/860