### PR TITLE
remove dummy cert references to Nginx Proxy Manager

### DIFF
--- a/docker/rootfs/etc/services.d/nginx/run
+++ b/docker/rootfs/etc/services.d/nginx/run
@@ -36,7 +36,7 @@ then
 		-days 3650 \
 		-nodes \
 		-x509 \
-		-subj '/O=Nginx Proxy Manager/OU=Dummy Certificate/CN=localhost' \
+		-subj '/O=localhost/OU=localhost/CN=localhost' \
 		-keyout /data/nginx/dummykey.pem \
 		-out /data/nginx/dummycert.pem
 	echo "Complete"


### PR DESCRIPTION
Based on this issue: https://github.com/jc21/nginx-proxy-manager/issues/1024