### PR TITLE
Add SSL and HTTP2 into IPv6 on listen.conf

### DIFF
--- a/backend/templates/_listen.conf
+++ b/backend/templates/_listen.conf
@@ -7,7 +7,7 @@
 {% if certificate -%}
   listen 443 ssl{% if http2_support %} http2{% endif %};
 {% if ipv6 -%}
-  listen [::]:443;
+  listen [::]:443 ssl{% if http2_support %} http2{% endif %};
 {% else -%}
   #listen [::]:443;
 {% endif %}


### PR DESCRIPTION
I can only serve contents with IPv6 because I'm sitting behind CGN on IPv4. When enabling HTTP2 it still not serve contents with HTTP2 as there are missing arguments in the `listen`. But it still does the SSL encryption.
Previous to this commit it generates:
```
listen 80;
listen [::]:80;

listen 443 ssl http2;
listen [::]:443;
```
Now it generates:
```
listen 80;
listen [::]:80;

listen 443 ssl http2;
listen [::]:443 ssl http2;
```