### PR TITLE
data.email should NOT be shorter than 8 characters #845

### DIFF
--- a/backend/schema/definitions.json
+++ b/backend/schema/definitions.json
@@ -153,7 +153,7 @@
       "example": "john@example.com",
       "format": "email",
       "type": "string",
-      "minLength": 8,
+      "minLength": 6,
       "maxLength": 100
     },
     "password": {


### PR DESCRIPTION
Change minimum value for characters in mail address from 8 to 6.

Seems to be a valid point in #845 

```
> ping a.ie
PING a.ie (79.170.244.15) 56(84) bytes of data.
64 bytes from parking.irishdomains.com (79.170.244.15): icmp_seq=1 ttl=63 time=37.8 ms
64 bytes from parking.irishdomains.com (79.170.244.15): icmp_seq=2 ttl=63 time=38.3 ms
64 bytes from parking.irishdomains.com (79.170.244.15): icmp_seq=3 ttl=63 time=37.6 ms
^C
--- a.ie ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2024ms
rtt min/avg/max/mdev = 37.634/37.932/38.317/0.285 ms
```

See also: https://answers.microsoft.com/en-us/outlook_com/forum/all/what-is-the-minimum-number-of-characters-allowed/fbfea6fd-7ba2-4d13-abab-50d9f71719a5