### PR TITLE
Add certificates/download language

### DIFF
--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -115,6 +115,9 @@
       "processing-info": "Processing... This might take a few minutes.",
       "passphrase-protection-support-info": "Key files protected with a passphrase are not supported."
     },
+    "certificates": {
+      "download": "Download"
+    },
     "proxy-hosts": {
       "title": "Proxy Hosts",
       "empty": "There are no Proxy Hosts",


### PR DESCRIPTION
The language for the SSL Certificate download button was not present.
![image](https://user-images.githubusercontent.com/63236817/135748077-d00ebce1-d96c-45e0-a193-ee2b3e858be2.png)
