### PR TITLE
Changes documentation to make SQLite the default db

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,28 +74,12 @@ services:
       - '80:80'
       - '81:81'
       - '443:443'
-    environment:
-      DB_MYSQL_HOST: "db"
-      DB_MYSQL_PORT: 3306
-      DB_MYSQL_USER: "npm"
-      DB_MYSQL_PASSWORD: "npm"
-      DB_MYSQL_NAME: "npm"
     volumes:
       - ./data:/data
       - ./letsencrypt:/etc/letsencrypt
-  db:
-    image: 'jc21/mariadb-aria:latest'
-    restart: unless-stopped
-    environment:
-      MYSQL_ROOT_PASSWORD: 'npm'
-      MYSQL_DATABASE: 'npm'
-      MYSQL_USER: 'npm'
-      MYSQL_PASSWORD: 'npm'
-    volumes:
-      - ./data/mysql:/var/lib/mysql
 ```
 
-3. Bring up your stack
+3. Bring up your stack by running
 
 ```bash
 docker-compose up -d

--- a/backend/index.js
+++ b/backend/index.js
@@ -44,84 +44,85 @@ async function appStart () {
 
 async function createDbConfigFromEnvironment() {
 	return new Promise((resolve, reject) => {
-		const envMysqlHost  = process.env.DB_MYSQL_HOST || null;
-		const envMysqlPort  = process.env.DB_MYSQL_PORT || null;
-		const envMysqlUser  = process.env.DB_MYSQL_USER || null;
-		const envMysqlName  = process.env.DB_MYSQL_NAME || null;
-		const envSqliteFile = process.env.DB_SQLITE_FILE || null;
+		const envMysqlHost = process.env.DB_MYSQL_HOST || null;
+		const envMysqlPort = process.env.DB_MYSQL_PORT || null;
+		const envMysqlUser = process.env.DB_MYSQL_USER || null;
+		const envMysqlName = process.env.DB_MYSQL_NAME || null;
+		let envSqliteFile  = process.env.DB_SQLITE_FILE || null;
 
-		if ((envMysqlHost && envMysqlPort && envMysqlUser && envMysqlName) || envSqliteFile) {
-			const fs       = require('fs');
-			const filename = (process.env.NODE_CONFIG_DIR || './config') + '/' + (process.env.NODE_ENV || 'default') + '.json';
-			let configData = {};
+		const fs       = require('fs');
+		const filename = (process.env.NODE_CONFIG_DIR || './config') + '/' + (process.env.NODE_ENV || 'default') + '.json';
+		let configData = {};
 
-			try {
-				configData = require(filename);
-			} catch (err) {
-				// do nothing
-			}
+		try {
+			configData = require(filename);
+		} catch (err) {
+			// do nothing
+		}
 
-			if (configData.database && configData.database.engine && !configData.database.fromEnv) {
-				logger.info('Manual db configuration already exists, skipping config creation from environment variables');
+		if (configData.database && configData.database.engine && !configData.database.fromEnv) {
+			logger.info('Manual db configuration already exists, skipping config creation from environment variables');
+			resolve();
+			return;
+		}
+
+		if ((!envMysqlHost || !envMysqlPort || !envMysqlUser || !envMysqlName) && !envSqliteFile){
+			envSqliteFile = '/data/database.sqlite';
+			logger.info(`No valid environment variables for database provided, using default SQLite file '${envSqliteFile}'`);
+		}
+
+		if (envMysqlHost && envMysqlPort && envMysqlUser && envMysqlName) {
+			const newConfig = {
+				fromEnv:  true,
+				engine:   'mysql',
+				host:     envMysqlHost,
+				port:     envMysqlPort,
+				user:     envMysqlUser,
+				password: process.env.DB_MYSQL_PASSWORD,
+				name:     envMysqlName,
+			};
+
+			if (JSON.stringify(configData.database) === JSON.stringify(newConfig)) {
+				// Config is unchanged, skip overwrite
 				resolve();
 				return;
 			}
 
-			if (envMysqlHost && envMysqlPort && envMysqlUser && envMysqlName) {
-				const newConfig = {
-					fromEnv:  true,
-					engine:   'mysql',
-					host:     envMysqlHost,
-					port:     envMysqlPort,
-					user:     envMysqlUser,
-					password: process.env.DB_MYSQL_PASSWORD,
-					name:     envMysqlName,
-				};
+			logger.info('Generating MySQL knex configuration from environment variables');
+			configData.database = newConfig;
 
-				if (JSON.stringify(configData.database) === JSON.stringify(newConfig)) {
-					// Config is unchanged, skip overwrite
-					resolve();
-					return;
+		} else {
+			const newConfig = {
+				fromEnv: true,
+				engine:  'knex-native',
+				knex:    {
+					client:     'sqlite3',
+					connection: {
+						filename: envSqliteFile
+					},
+					useNullAsDefault: true
 				}
-
-				logger.info('Generating MySQL db configuration from environment variables');
-				configData.database = newConfig;
-
-			} else {
-				const newConfig = {
-					fromEnv: true,
-					engine:  'knex-native',
-					knex:    {
-						client:     'sqlite3',
-						connection: {
-							filename: envSqliteFile
-						},
-						useNullAsDefault: true
-					}
-				};
-				if (JSON.stringify(configData.database) === JSON.stringify(newConfig)) {
-					// Config is unchanged, skip overwrite
-					resolve();
-					return;
-				}
-
-				logger.info('Generating Sqlite db configuration from environment variables');
-				configData.database = newConfig;
+			};
+			if (JSON.stringify(configData.database) === JSON.stringify(newConfig)) {
+				// Config is unchanged, skip overwrite
+				resolve();
+				return;
 			}
 
-			// Write config
-			fs.writeFile(filename, JSON.stringify(configData, null, 2), (err) => {
-				if (err) {
-					logger.error('Could not write db config to config file: ' + filename);
-					reject(err);
-				} else {
-					logger.info('Wrote db configuration to config file: ' + filename);
-					resolve();
-				}
-			});
-		} else {
-			resolve();
+			logger.info('Generating SQLite knex configuration');
+			configData.database = newConfig;
 		}
+
+		// Write config
+		fs.writeFile(filename, JSON.stringify(configData, null, 2), (err) => {
+			if (err) {
+				logger.error('Could not write db config to config file: ' + filename);
+				reject(err);
+			} else {
+				logger.debug('Wrote db configuration to config file: ' + filename);
+				resolve();
+			}
+		});
 	});
 }
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -1,6 +1,44 @@
 # Full Setup Instructions
 
-## MySQL Database
+## Running the App
+
+Create a `docker-compose.yml` file:
+
+```yml
+version: "3"
+services:
+  app:
+    image: 'jc21/nginx-proxy-manager:latest'
+    restart: unless-stopped
+    ports:
+      # These ports are in format <host-port>:<container-port>
+      - '80:80' # Public HTTP Port
+      - '443:443' # Public HTTPS Port
+      - '81:81' # Admin Web Port
+      # Add any other Stream port you want to expose
+      # - '21:21' # FTP
+
+    # Uncomment the next line if you uncomment anything in the section
+    # environment:
+      # Uncomment this if you want to change the location of 
+      # the SQLite DB file within the container
+      # DB_SQLITE_FILE: "/data/database.sqlite"
+
+      # Uncomment this if IPv6 is not enabled on your host
+      # DISABLE_IPV6: 'true'
+
+    volumes:
+      - ./data:/data
+      - ./letsencrypt:/etc/letsencrypt
+```
+
+Then:
+
+```bash
+docker-compose up -d
+```
+
+## Using MySQL / MariaDB Database
 
 If you opt for the MySQL configuration you will have to provide the database server yourself. You can also use MariaDB. Here are the minimum supported versions:
 
@@ -10,15 +48,7 @@ If you opt for the MySQL configuration you will have to provide the database ser
 It's easy to use another docker container for your database also and link it as part of the docker stack, so that's what the following examples
 are going to use.
 
-::: warning
-
-When using a `mariadb` database, the NPM configuration file should still use the `mysql` engine!
-
-:::
-
-## Running the App
-
-Via `docker-compose`:
+Here is an example of what your `docker-compose.yml` will look like when using a MariaDB container:
 
 ```yml
 version: "3"
@@ -27,24 +57,18 @@ services:
     image: 'jc21/nginx-proxy-manager:latest'
     restart: unless-stopped
     ports:
-      # Public HTTP Port:
-      - '80:80'
-      # Public HTTPS Port:
-      - '443:443'
-      # Admin Web Port:
-      - '81:81'
+      # These ports are in format <host-port>:<container-port>
+      - '80:80' # Public HTTP Port
+      - '443:443' # Public HTTPS Port
+      - '81:81' # Admin Web Port
       # Add any other Stream port you want to expose
       # - '21:21' # FTP
     environment:
-      # These are the settings to access your db
       DB_MYSQL_HOST: "db"
       DB_MYSQL_PORT: 3306
       DB_MYSQL_USER: "npm"
       DB_MYSQL_PASSWORD: "npm"
       DB_MYSQL_NAME: "npm"
-      # If you would rather use Sqlite uncomment this
-      # and remove all DB_MYSQL_* lines above
-      # DB_SQLITE_FILE: "/data/database.sqlite"
       # Uncomment this if IPv6 is not enabled on your host
       # DISABLE_IPV6: 'true'
     volumes:
@@ -52,6 +76,7 @@ services:
       - ./letsencrypt:/etc/letsencrypt
     depends_on:
       - db
+
   db:
     image: 'jc21/mariadb-aria:latest'
     restart: unless-stopped
@@ -64,13 +89,11 @@ services:
       - ./data/mysql:/var/lib/mysql
 ```
 
-_Please note, that `DB_MYSQL_*` environment variables will take precedent over `DB_SQLITE_*` variables. So if you keep the MySQL variables, you will not be able to use Sqlite._
+::: warning
 
-Then:
+Please note, that `DB_MYSQL_*` environment variables will take precedent over `DB_SQLITE_*` variables. So if you keep the MySQL variables, you will not be able to use SQLite.
 
-```bash
-docker-compose up -d
-```
+:::
 
 ## Running on Raspberry PI / ARM devices
 
@@ -89,57 +112,7 @@ for a list of supported architectures and if you want one that doesn't exist,
 Also, if you don't know how to already, follow [this guide to install docker and docker-compose](https://manre-universe.net/how-to-run-docker-and-docker-compose-on-raspbian/)
 on Raspbian.
 
-Via `docker-compose`:
-
-```yml
-version: "3"
-services:
-  app:
-    image: 'jc21/nginx-proxy-manager:latest'
-    restart: unless-stopped
-    ports:
-      # Public HTTP Port:
-      - '80:80'
-      # Public HTTPS Port:
-      - '443:443'
-      # Admin Web Port:
-      - '81:81'
-    environment:
-      # These are the settings to access your db
-      DB_MYSQL_HOST: "db"
-      DB_MYSQL_PORT: 3306
-      DB_MYSQL_USER: "changeuser"
-      DB_MYSQL_PASSWORD: "changepass"
-      DB_MYSQL_NAME: "npm"
-      # If you would rather use Sqlite uncomment this
-      # and remove all DB_MYSQL_* lines above
-      # DB_SQLITE_FILE: "/data/database.sqlite"
-      # Uncomment this if IPv6 is not enabled on your host
-      # DISABLE_IPV6: 'true'
-    volumes:
-      - ./data/nginx-proxy-manager:/data
-      - ./letsencrypt:/etc/letsencrypt
-    depends_on:
-      - db
-  db:
-    image: yobasystems/alpine-mariadb:latest
-    restart: unless-stopped
-    environment:
-      MYSQL_ROOT_PASSWORD: "changeme"
-      MYSQL_DATABASE: "npm"
-      MYSQL_USER: "changeuser"
-      MYSQL_PASSWORD: "changepass"
-    volumes:
-      - ./data/mariadb:/var/lib/mysql
-```
-
-_Please note, that `DB_MYSQL_*` environment variables will take precedent over `DB_SQLITE_*` var>
-
-Then:
-
-```bash
-docker-compose up -d
-```
+Please note that the `jc21/mariadb-aria:latest` image might have some problems on some ARM devices, if you want a separate database container, use the `yobasystems/alpine-mariadb:latest` image.
 
 ## Initial Run
 


### PR DESCRIPTION
- Removes the MariaDB entirely from the quick start guide
- Uses SQLite file by default if no environment variables / config file is provided
- Changes full installation guide to make MariaDB an optional advanced config