### PR TITLE
Fixes custom location with capture groups

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,5 +1,10 @@
   location {{ path }} {
-    set              $targetUri {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }}{% unless path contains "(" %}$request_uri{% endunless %};
+    set              $targetUri {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
+    {% unless path contains "~" and path contains "(" and path contains ")" %}
+    if ($request_uri != /){
+      set            $targetUri $targetUri$request_uri;
+    }
+    {% endunless %}
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,11 +1,11 @@
   location {{ path }} {
-    set              $upstream {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }}$request_uri;
+    set              $targetUri {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }}{% unless path contains "(" %}$request_uri{% endunless %};
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-For    $remote_addr;
     proxy_set_header X-Real-IP		$remote_addr;
-    proxy_pass       $upstream;
+    proxy_pass       $targetUri;
 
     {% if access_list_id > 0 %}
     {% if access_list.items.length > 0 %}

--- a/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
@@ -1,9 +1,9 @@
-set              $upstream $forward_scheme://$server:$port$request_uri;
+set              $targetUri $forward_scheme://$server:$port$request_uri;
 add_header       X-Served-By $host;
 proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Scheme $scheme;
 proxy_set_header X-Forwarded-Proto  $scheme;
 proxy_set_header X-Forwarded-For    $remote_addr;
 proxy_set_header X-Real-IP          $remote_addr;
-proxy_pass       $upstream;
+proxy_pass       $targetUri;
 


### PR DESCRIPTION
- Renames `$upstream` to `$targetUri` in ngix config templates to prevent collision
- Does not append `$request_uri` to the url of a location if the location contains an opening bracket `(`, a closing bracket `(` and a tilde `~` signaling a regex capture group
- Does not append `$request_uri` if it is basically empty, so just a slash `/` as this would break domain-only requests (requests without a path)

Fixes https://github.com/jc21/nginx-proxy-manager/issues/1319