### PR TITLE
Adds advanced config header warning

### DIFF
--- a/frontend/js/app/nginx/proxy/form.ejs
+++ b/frontend/js/app/nginx/proxy/form.ejs
@@ -257,16 +257,17 @@
                 <div role="tabpanel" class="tab-pane" id="advanced">
                     <div class="row">
                         <div class="col-md-12">
-                            <p>Nginx variables available to you are:</p>
+                            <p><%- i18n('all-hosts', 'advanced-config-var-headline') %></p>
                             <ul class="text-monospace">
-                                <li>$server          # Host/IP</li>
-                                <li>$port            # Port Number</li>
-                                <li>$forward_scheme  # http or https</li>
+                                <li><code>$server</code> <%- i18n('proxy-hosts', 'forward-host') %></li>
+                                <li><code>$port</code> <%- i18n('proxy-hosts', 'forward-port') %></li>
+                                <li><code>$forward_scheme</code> <%- i18n('proxy-hosts', 'forward-scheme') %></li>
                             </ul>
                             <div class="form-group mb-0">
                                 <label class="form-label"><%- i18n('all-hosts', 'advanced-config') %></label>
                                 <textarea name="advanced_config" rows="8" class="form-control text-monospace" placeholder="# <%- i18n('all-hosts', 'advanced-warning') %>"><%- advanced_config %></textarea>
                             </div>
+                            <p class="small text-gray"><i class="fe fe-alert-triangle"></i> <%- i18n('all-hosts', 'advanced-config-header-info') %></p>
                         </div>
                     </div>
                 </div>

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -84,6 +84,8 @@
       "advanced": "Advanced",
       "advanced-warning": "Enter your custom Nginx configuration here at your own risk!",
       "advanced-config": "Custom Nginx Configuration",
+      "advanced-config-var-headline": "These proxy details are available as nginx variables:",
+      "advanced-config-header-info": "Please note, that any add_header or set_header directives added here will not be used by nginx. You will have to add a custom location '/' and add the header in the custom config there.",
       "hsts-enabled": "HSTS Enabled",
       "hsts-subdomains": "HSTS Subdomains",
       "locations": "Custom locations"


### PR DESCRIPTION
- Adds a warning that `add_header` directives will not be used when adding them to the advanced config, but instead a custom location would have to be added
- Replaces the info about additional available variables with a translation string

![image](https://user-images.githubusercontent.com/26956711/140302167-f549fef0-9160-47f9-9013-c2e254096a7b.png)
