### PR TITLE
Removes HSTS from admin ui

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -40,7 +40,6 @@ app.use(function (req, res, next) {
 	}
 
 	res.set({
-		'Strict-Transport-Security': 'includeSubDomains; max-age=631138519; preload',
 		'X-XSS-Protection':          '1; mode=block',
 		'X-Content-Type-Options':    'nosniff',
 		'X-Frame-Options':           x_frame_options,

--- a/backend/app.js
+++ b/backend/app.js
@@ -40,12 +40,12 @@ app.use(function (req, res, next) {
 	}
 
 	res.set({
-		'X-XSS-Protection':          '1; mode=block',
-		'X-Content-Type-Options':    'nosniff',
-		'X-Frame-Options':           x_frame_options,
-		'Cache-Control':             'no-cache, no-store, max-age=0, must-revalidate',
-		Pragma:                      'no-cache',
-		Expires:                     0
+		'X-XSS-Protection':       '1; mode=block',
+		'X-Content-Type-Options': 'nosniff',
+		'X-Frame-Options':        x_frame_options,
+		'Cache-Control':          'no-cache, no-store, max-age=0, must-revalidate',
+		Pragma:                   'no-cache',
+		Expires:                  0
 	});
 	next();
 });


### PR DESCRIPTION
Removes HSTS header from admin ui (port 81). Since it is not ssl encrypted by default and it is not possible to natively encrypt it this should not be there. This should be settable in a proxy host created to proxy the admin ui, otherwise the header would always be set, even if the proxy host does not have it set.

Fixes https://github.com/jc21/nginx-proxy-manager/issues/1560