### PR TITLE
Reverts back to proxy_pass without variables

### DIFF
--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,16 +1,10 @@
   location {{ path }} {
-    set              $targetUri {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
-    {% unless path contains "~" and path contains "(" and path contains ")" %}
-    if ($request_uri != /){
-      set            $targetUri $targetUri$request_uri;
-    }
-    {% endunless %}
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Scheme $scheme;
     proxy_set_header X-Forwarded-Proto  $scheme;
     proxy_set_header X-Forwarded-For    $remote_addr;
     proxy_set_header X-Real-IP		$remote_addr;
-    proxy_pass       $targetUri;
+    proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
 
     {% if access_list_id > 0 %}
     {% if access_list.items.length > 0 %}

--- a/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
@@ -1,9 +1,8 @@
-set              $targetUri $forward_scheme://$server:$port$request_uri;
 add_header       X-Served-By $host;
 proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Scheme $scheme;
 proxy_set_header X-Forwarded-Proto  $scheme;
 proxy_set_header X-Forwarded-For    $remote_addr;
 proxy_set_header X-Real-IP          $remote_addr;
-proxy_pass       $targetUri;
+proxy_pass       $forward_scheme://$server:$port$request_uri;
 


### PR DESCRIPTION
So apparently using the variable for the `proxy_pass` directive comes with a whole load of issues which are not easily fixable, and break how locations are expected to work. This reverts the template back to the normal `proxy_pass` usage without storing the target in a variable.