### PR TITLE
Update default.conf to follow the default site setting also for ipv6

### DIFF
--- a/backend/templates/default.conf
+++ b/backend/templates/default.conf
@@ -7,9 +7,9 @@
 server {
   listen 80 default;
 {% if ipv6 -%}
-  listen [::]:80;
+  listen [::]:80 default;
 {% else -%}
-  #listen [::]:80;
+  #listen [::]:80 default;
 {% endif %}
   server_name default-host.localhost;
   access_log /data/logs/default-host_access.log combined;


### PR DESCRIPTION
Follow the default site setting also if using IPv6.
Fixes #1347 