### PR TITLE
Fixed generation of resolvers.conf.

### DIFF
--- a/docker/rootfs/etc/services.d/nginx/run
+++ b/docker/rootfs/etc/services.d/nginx/run
@@ -24,7 +24,7 @@ chown root /tmp/nginx
 
 # Dynamically generate resolvers file, if resolver is IPv6, enclose in `[]`
 # thanks @tfmm
-echo resolver "$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf);" > /etc/nginx/conf.d/include/resolvers.conf
+echo resolver "$(awk 'BEGIN{ORS=" "} $1=="nameserver" { sub(/%.*$/,"",$2); print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf);" > /etc/nginx/conf.d/include/resolvers.conf
 
 # Generate dummy self-signed certificate.
 if [ ! -f /data/nginx/dummycert.pem ] || [ ! -f /data/nginx/dummykey.pem ]


### PR DESCRIPTION
This fixes scenarios where `resolv.conf` generated by dhcpcd has a nameserver with `%interface` appended to its IPv6 address.
For example, a line like this must be properly handled:
nameserver fe80::7747:4aff:fe9a:8cb1%br0