### PR TITLE
Adds delay after reloading nginx before requesting ssl certificate using http challenge

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -171,6 +171,7 @@ const internalCertificate = {
 								// 3. Generate the LE config
 								return internalNginx.generateLetsEncryptRequestConfig(certificate)
 									.then(internalNginx.reload)
+									.then(async() => await new Promise((r) => setTimeout(r, 5000)))
 									.then(() => {
 										// 4. Request cert
 										return internalCertificate.requestLetsEncryptSsl(certificate);


### PR DESCRIPTION
Maybe this helps some people having issues with the request of certbot certificates via http challenge, e.g. from https://github.com/jc21/nginx-proxy-manager/issues/881